### PR TITLE
Bumped Jacoco version to 0.7.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Find some useful links below:
 
 ## Latest API Docs 
 
-Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M5-SNAPSHOT">4.0.0-M5-SNAPSHOT</a>.
+Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M9-SNAPSHOT">4.0.0-M9-SNAPSHOT</a>.
 
 ## Prerequisites
 
@@ -49,7 +49,7 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 ## Features
 
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M5-SNAPSHOT/#rdbms-store">rdbms</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#stores">Store</a>)*<br><div style="padding-left: 1em;"><p>This extension assigns data sources and connection instructions to event tables. It also implements read write operations on connected datasources</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M9-SNAPSHOT/#rdbms-store">rdbms</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#stores">Store</a>)*<br><div style="padding-left: 1em;"><p>This extension assigns data sources and connection instructions to event tables. It also implements read write operations on connected datasources</p></div>
 
 ## How to Contribute
  

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ Find some useful links below:
 
 ## Latest API Docs 
 
-Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M5-SNAPSHOT">4.0.0-M5-SNAPSHOT</a>.
+Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M9-SNAPSHOT">4.0.0-M9-SNAPSHOT</a>.
 
 ## Prerequisites
 
@@ -49,7 +49,7 @@ Latest API Docs is <a target="_blank" href="https://wso2-extensions.github.io/si
 
 ## Features
 
-* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M5-SNAPSHOT/#rdbms-store">rdbms</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#stores">Store</a>)*<br><div style="padding-left: 1em;"><p>This extension assigns data sources and connection instructions to event tables. It also implements read write operations on connected datasources</p></div>
+* <a target="_blank" href="https://wso2-extensions.github.io/siddhi-store-rdbms/api/4.0.0-M9-SNAPSHOT/#rdbms-store">rdbms</a> *(<a target="_blank" href="https://wso2.github.io/siddhi/documentation/siddhi-4.0/#stores">Store</a>)*<br><div style="padding-left: 1em;"><p>This extension assigns data sources and connection instructions to event tables. It also implements read write operations on connected datasources</p></div>
 
 ## How to Contribute
  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,5 +16,9 @@ pages:
 - Welcome to WSO2 Siddhi Store RDBMS: index.md
 - API Docs:
   - 4.0.0-M5-SNAPSHOT: api/4.0.0-M5-SNAPSHOT.md
+  - 4.0.0-M6-SNAPSHOT: api/4.0.0-M6-SNAPSHOT.md
+  - 4.0.0-M7-SNAPSHOT: api/4.0.0-M7-SNAPSHOT.md
+  - 4.0.0-M8-SNAPSHOT: api/4.0.0-M8-SNAPSHOT.md
+  - 4.0.0-M9-SNAPSHOT: api/4.0.0-M9-SNAPSHOT.md
 - License: license.md
 theme: material

--- a/pom.xml
+++ b/pom.xml
@@ -85,8 +85,8 @@
         <pax.exam.link.mvn.version>4.6.0</pax.exam.link.mvn.version>
         <pax.exam.container.native.version>4.6.0</pax.exam.container.native.version>
         <pax.url.aether.version>1.6.0</pax.url.aether.version>
-        <org.jacoco.ant.version>0.7.5.201505241946</org.jacoco.ant.version>
-        <jacoco.plugin.version>0.7.5.201505241946</jacoco.plugin.version>
+        <org.jacoco.ant.version>0.7.9</org.jacoco.ant.version>
+        <jacoco.plugin.version>0.7.9</jacoco.plugin.version>
         <ow2.jta.spec.version>1.0.12</ow2.jta.spec.version>
         <commons.io.version>1.3.2</commons.io.version>
         <osgi.test.util.version>5.1.1</osgi.test.util.version>


### PR DESCRIPTION
## Purpose
Standardizing the version of Jacoco plugin used

## Approach
Bumped Jacoco version to 0.7.9

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes