### PR TITLE
Fixing issue: 42

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -642,7 +642,6 @@ public class RDBMSEventTable extends AbstractRecordTable {
                                                   Map<String, CompiledExpression> updateSetExpressions,
                                                   List<Map<String, Object>> updateSetParameterMaps) {
         int counter = 0;
-        final int seed = this.attributes.size();
         Connection conn = this.getConnection(false);
         PreparedStatement updateStmt = null;
         List<Integer> updateResultList = new ArrayList<>();
@@ -674,7 +673,7 @@ public class RDBMSEventTable extends AbstractRecordTable {
 
                 //Incrementing the ordinals of the conditions in the statement with the # of variables to be updated
                 RDBMSTableUtils.resolveCondition(updateStmt, (RDBMSCompiledCondition) compiledCondition,
-                        conditionParameters, seed);
+                        conditionParameters, ordinal - 1);
                 int isUpdate = updateStmt.executeUpdate();
                 conn.commit();
                 if (isUpdate < 1) {


### PR DESCRIPTION
## Purpose
>  Resolves issue 'Set support test cases are failing for OracleDB #42'.

## Goals
> Removing seed variable in 'sequentialProcessUpdate' as it should be replaced by the ordinal variable we had introduced for the set operator.

## Approach
> Debugging the setInsertOrUpdate flow with oracle docker test and fixed the above-explained.

## Release note
> bug fix: Set support test cases are failing for OracleDB #42

## Documentation
> "N/A", this will not affect the API changes in the component, hence docs changes are not required.

## Automation tests
 - Integration tests
   > This issue is reported with the set support test cases failure for OracleDB.

## Security checks
 - yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> JDK 1.8, operating systems Ubuntu 16.04 LTS, databases {Oracle11c| MySQL|MSSQL|H2|DB2}.