### PR TITLE
Correct forming condition for attribute functions

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSConditionVisitor.java
@@ -282,7 +282,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     @Override
     public void endVisitAttributeFunction(String namespace, String functionName) {
         if (RDBMSTableUtils.isEmpty(namespace)) {
-            condition.append(RDBMSTableConstants.OPEN_PARENTHESIS).append(RDBMSTableConstants.WHITESPACE);
+            condition.append(RDBMSTableConstants.CLOSE_PARENTHESIS).append(RDBMSTableConstants.WHITESPACE);
         } else {
             throw new OperationNotSupportedException("The RDBMS Event table does not support function namespaces, " +
                     "but namespace '" + namespace + "' was specified. Please use functions supported by the " +


### PR DESCRIPTION
## Purpose
> Correct forming condition for attribute functions. The condition must end with a close parenthesis

