### PR TITLE
Adding contains check feature in RDBMS store

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>sqljdbc4</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.extension.siddhi.execution.string</groupId>
+            <artifactId>siddhi-execution-string</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!--<dependency>-->
             <!--<groupId>com.ibm.db2</groupId>-->
             <!--<artifactId>db2jcc</artifactId>-->
@@ -736,7 +741,7 @@
                                             <port>${das-db2.port}:50000</port>
                                         </ports>
                                         <wait>
-                                            <log>SQL1063N DB2START processing was successful.</log>
+                                            <log>SQL1063N  DB2START processing was successful.</log>
                                             <time>10000</time>
                                         </wait>
                                     </run>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -96,11 +96,6 @@
             <artifactId>sqljdbc4</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.extension.siddhi.execution.string</groupId>
-            <artifactId>siddhi-execution-string</artifactId>
-            <scope>test</scope>
-        </dependency>
         <!--<dependency>-->
             <!--<groupId>com.ibm.db2</groupId>-->
             <!--<artifactId>db2jcc</artifactId>-->

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSCompiledCondition.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSCompiledCondition.java
@@ -29,19 +29,29 @@ public class RDBMSCompiledCondition implements CompiledCondition {
 
     private String compiledQuery;
     private SortedMap<Integer, Object> parameters;
+    private boolean isContainsConditionExist;
+    private int ordinalOfContainPattern;
 
-    public RDBMSCompiledCondition(String compiledQuery, SortedMap<Integer, Object> parameters) {
+    public RDBMSCompiledCondition(String compiledQuery, SortedMap<Integer, Object> parameters,
+                                  boolean isContainsConditionExist, int ordinalOfContainPattern) {
         this.compiledQuery = compiledQuery;
         this.parameters = parameters;
+        this.isContainsConditionExist = isContainsConditionExist;
+        this.ordinalOfContainPattern = ordinalOfContainPattern;
     }
 
     @Override
     public CompiledCondition cloneCompilation(String key) {
-        return new RDBMSCompiledCondition(this.compiledQuery, this.parameters);
+        return new RDBMSCompiledCondition(this.compiledQuery, this.parameters,
+                this.isContainsConditionExist, this.ordinalOfContainPattern);
     }
 
     public String getCompiledQuery() {
         return compiledQuery;
+    }
+
+    public boolean isContainsConditionExist() {
+        return isContainsConditionExist;
     }
 
     public String toString() {
@@ -50,5 +60,9 @@ public class RDBMSCompiledCondition implements CompiledCondition {
 
     public SortedMap<Integer, Object> getParameters() {
         return parameters;
+    }
+
+    public int getOrdinalOfContainPattern() {
+        return ordinalOfContainPattern;
     }
 }

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSConditionVisitor.java
@@ -289,7 +289,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     public void beginVisitAttributeFunction(String namespace, String functionName) {
         if (RDBMSTableUtils.isEmpty(namespace)) {
             condition.append(functionName).append(RDBMSTableConstants.OPEN_PARENTHESIS);
-        } else if ((namespace.trim().equals("str") && functionName.equals("contain"))) {
+        } else if ((namespace.trim().equals("str") && functionName.equals("contains"))) {
             condition.append("CONTAINS").append(RDBMSTableConstants.OPEN_PARENTHESIS);
             isContainsConditionExist = true;
             nextProcessContainsPattern = true;

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -91,8 +91,10 @@ import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PLA
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PLACEHOLDER_INDEX;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PLACEHOLDER_Q;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PLACEHOLDER_TABLE_NAME;
+import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PLACEHOLDER_VALUES;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.PROPERTY_SEPARATOR;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.QUESTION_MARK;
+import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.RECORD_CONTAINS_CONDITION;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.RECORD_DELETE_QUERY;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.RECORD_EXISTS_QUERY;
 import static org.wso2.extension.siddhi.store.rdbms.util.RDBMSTableConstants.RECORD_INSERT_QUERY;
@@ -174,14 +176,32 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
                         syntax = "@Store(type=\"rdbms\", jdbc.url=\"jdbc:mysql://localhost:3306/das\", " +
                                 "username=\"root\", password=\"root\" , jdbc.driver.name=\"org.h2.Driver\"," +
                                 "field.length=\"symbol:100\")\n" +
-                                "@PrimaryKey(\"symbol\")" +
-                                "@Index(\"volume\")" +
+                                "@PrimaryKey(\"symbol\")\n" +
+                                "@Index(\"volume\")\n" +
                                 "define table StockTable (symbol string, price float, volume long);",
                         description = "The above example creates an event table named `StockTable` on the DB if " +
                                 "it does not already exist (with 3 attributes named `symbol`, `price`, and `volume` " +
                                 "of the types types `string`, `float` and `long` respectively). The connection is " +
                                 "made as specified by the parameters configured for the '@Store' annotation. The " +
                                 "`symbol` attribute is considered a unique field, and a DB index is created for it."
+                ),
+                @Example(
+                        syntax = "@Store(type=\"rdbms\", jdbc.url=\"jdbc:mysql://localhost:3306/das\", " +
+                                "username=\"root\", password=\"root\" , jdbc.driver.name=\"org.h2.Driver\"," +
+                                "field.length=\"symbol:100\")\n" +
+                                "@PrimaryKey(\"symbol\")\n" +
+                                "@Index(\"symbol\")\n" +
+                                "define table StockTable (symbol string, price float, volume long);\n" +
+                                "define stream InputStream (symbol string, volume long);\n" +
+                                "from InputStream as a join StockTable as b on str:contain(b.symbol, a.symbol)\n" +
+                                "select a.symbol as symbol, b.volume as volume\n" +
+                                "insert into FooStream;",
+                        description = "The above example creates an event table named `StockTable` on the DB if " +
+                                "it does not already exist (with 3 attributes named `symbol`, `price`, and `volume` " +
+                                "of the types types `string`, `float` and `long` respectively). Then the table is " +
+                                "join with the InputStream based on a condition. In the on condition following " +
+                                "operations are supported [ AND, OR, Comparisons( <  <=  >  >=  == !=), IS NULL, " +
+                                "NOT, str:contain(Table<Column>, Stream<Attribute> or Search.String)]"
                 )
         },
         systemParameter = {
@@ -379,6 +399,8 @@ public class RDBMSEventTable extends AbstractRecordTable {
     private String longType;
     private String stringType;
     private String stringSize;
+    private String recordContainsConditionTemplate;
+    private String findCondition;
 
     @Override
     protected void init(TableDefinition tableDefinition, ConfigReader configReader) {
@@ -416,13 +438,21 @@ public class RDBMSEventTable extends AbstractRecordTable {
     @Override
     protected RecordIterator<Object[]> find(Map<String, Object> findConditionParameterMap,
                                             CompiledCondition compiledCondition) {
-        String condition = ((RDBMSCompiledCondition) compiledCondition).getCompiledQuery();
+        RDBMSCompiledCondition rdbmsCompiledCondition = (RDBMSCompiledCondition) compiledCondition;
+        if (findCondition == null) {
+            if (rdbmsCompiledCondition.isContainsConditionExist()) {
+                findCondition = RDBMSTableUtils.processFindConditionWithContainsConditionTemplate(
+                        rdbmsCompiledCondition.getCompiledQuery(), this.recordContainsConditionTemplate);
+            } else {
+                findCondition = rdbmsCompiledCondition.getCompiledQuery();
+            }
+        }
         //Some databases does not support single condition on where clause.
         //(atomic condition on where clause: SELECT * FROM TABLE WHERE true)
         //If the compile condition is resolved for '?', atomicCondition boolean value
         // will be used for ignore condition resolver.
         boolean atomicCondition = false;
-        if (condition.equals(QUESTION_MARK)) {
+        if (findCondition.equals(QUESTION_MARK)) {
             atomicCondition = true;
             if (log.isDebugEnabled()) {
                 log.debug("Ignore the condition resolver in 'find()' method for compile " +
@@ -433,12 +463,18 @@ public class RDBMSEventTable extends AbstractRecordTable {
         PreparedStatement stmt = null;
         ResultSet rs;
         try {
-            stmt = RDBMSTableUtils.isEmpty(condition) | atomicCondition ?
+            stmt = RDBMSTableUtils.isEmpty(findCondition) | atomicCondition ?
                     conn.prepareStatement(selectQuery.replace(PLACEHOLDER_CONDITION, "")) :
-                    conn.prepareStatement(RDBMSTableUtils.formatQueryWithCondition(selectQuery, condition));
+                    conn.prepareStatement(RDBMSTableUtils.formatQueryWithCondition(selectQuery, findCondition));
             if (!atomicCondition) {
-                RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
-                        findConditionParameterMap, 0);
+                if (rdbmsCompiledCondition.isContainsConditionExist()) {
+
+                    RDBMSTableUtils.resolveConditionForContainsCheck(stmt, (RDBMSCompiledCondition) compiledCondition,
+                            findConditionParameterMap, 0);
+                } else {
+                    RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
+                            findConditionParameterMap, 0);
+                }
             }
             rs = stmt.executeQuery();
             //Passing all java.sql artifacts to the iterator to ensure everything gets cleaned up at once.
@@ -713,7 +749,8 @@ public class RDBMSEventTable extends AbstractRecordTable {
     protected CompiledCondition compileCondition(ExpressionBuilder expressionBuilder) {
         RDBMSConditionVisitor visitor = new RDBMSConditionVisitor(this.tableName);
         expressionBuilder.build(visitor);
-        return new RDBMSCompiledCondition(visitor.returnCondition(), visitor.getParameters());
+        return new RDBMSCompiledCondition(visitor.returnCondition(), visitor.getParameters(),
+                visitor.isContainsConditionExist(), visitor.getOrdinalOfContainPattern());
     }
 
 
@@ -818,6 +855,10 @@ public class RDBMSEventTable extends AbstractRecordTable {
                     stringSize = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                     PROPERTY_SEPARATOR + STRING_SIZE,
                             this.queryConfigurationEntry.getStringSize());
+                    recordContainsConditionTemplate = configReader.readConfig(
+                            this.queryConfigurationEntry.getDatabaseName() + PROPERTY_SEPARATOR +
+                                    RECORD_CONTAINS_CONDITION, this.queryConfigurationEntry.
+                                    getRecordContainsCondition()).replace(PLACEHOLDER_VALUES, QUESTION_MARK);
                 }
             }
             if (!this.tableExists()) {

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -193,7 +193,7 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
                                 "@Index(\"symbol\")\n" +
                                 "define table StockTable (symbol string, price float, volume long);\n" +
                                 "define stream InputStream (symbol string, volume long);\n" +
-                                "from InputStream as a join StockTable as b on str:contain(b.symbol, a.symbol)\n" +
+                                "from InputStream as a join StockTable as b on str:contains(b.symbol, a.symbol)\n" +
                                 "select a.symbol as symbol, b.volume as volume\n" +
                                 "insert into FooStream;",
                         description = "The above example creates an event table named `StockTable` on the DB if " +
@@ -201,7 +201,7 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
                                 "of the types types `string`, `float` and `long` respectively). Then the table is " +
                                 "join with the InputStream based on a condition. In the on condition following " +
                                 "operations are supported [ AND, OR, Comparisons( <  <=  >  >=  == !=), IS NULL, " +
-                                "NOT, str:contain(Table<Column>, Stream<Attribute> or Search.String)]"
+                                "NOT, str:contains(Table<Column>, Stream<Attribute> or Search.String)]"
                 )
         },
         systemParameter = {

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/config/RDBMSQueryConfigurationEntry.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/config/RDBMSQueryConfigurationEntry.java
@@ -46,6 +46,7 @@ public class RDBMSQueryConfigurationEntry {
     private int batchSize;
     private boolean batchEnable = false;
     private boolean transactionSupported = true;
+    private String recordContainsCondition;
 
     @XmlAttribute(name = "name", required = true)
     public String getDatabaseName() {
@@ -158,6 +159,14 @@ public class RDBMSQueryConfigurationEntry {
     @XmlElement(required = true)
     public String getRecordDeleteQuery() {
         return recordDeleteQuery;
+    }
+
+    public String getRecordContainsCondition() {
+        return recordContainsCondition;
+    }
+
+    public void setRecordContainsCondition(String recordContainsCondition) {
+        this.recordContainsCondition = recordContainsCondition;
     }
 
     public void setRecordDeleteQuery(String recordDeleteQuery) {

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableConstants.java
@@ -35,6 +35,7 @@ public class RDBMSTableConstants {
     public static final String PLACEHOLDER_INDEX = "{{INDEX_COLUMNS}}";
     public static final String PLACEHOLDER_Q = "{{Q}}";
     public static final String PLACEHOLDER_COLUMNS = "{{COLUMNS}}";
+    public static final String PLACEHOLDER_VALUES = "{{VALUES}}";
 
     //Miscellaneous SQL constants
     public static final String SQL_MATH_ADD = "+";
@@ -63,6 +64,8 @@ public class RDBMSTableConstants {
     public static final String OPEN_PARENTHESIS = "(";
     public static final String CLOSE_PARENTHESIS = ")";
 
+    public static final String CONTAINS_CONDITION_REGEX = "(CONTAINS\\()([a-zA-z.]*)(\\s\\?\\s\\))";
+
     //Annotation field names
     public static final String ANNOTATION_ELEMENT_URL = "jdbc.url";
     public static final String ANNOTATION_ELEMENT_USERNAME = "username";
@@ -86,6 +89,7 @@ public class RDBMSTableConstants {
     public static final String RECORD_SELECT_QUERY = "recordSelectQuery";
     public static final String RECORD_EXISTS_QUERY = "recordExistsQuery";
     public static final String RECORD_DELETE_QUERY = "recordDeleteQuery";
+    public static final String RECORD_CONTAINS_CONDITION = "recordContainsCondition";
     public static final String STRING_SIZE = "stringSize";
     public static final String TYPE_MAPPING = "typeMapping";
     public static final String BINARY_TYPE = "binaryType";

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -10,6 +10,7 @@
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}}
             {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>{{COLUMNS}} LIKE {{VALUES}}</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
@@ -32,6 +33,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
@@ -54,6 +56,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>false</batchEnable>
         <batchSize>1000</batchSize>
@@ -76,6 +79,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
@@ -98,6 +102,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
@@ -120,6 +125,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
@@ -142,6 +148,7 @@
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <keyExplicitNotNull>true</keyExplicitNotNull>
         <stringSize>254</stringSize>
         <batchEnable>true</batchEnable>

--- a/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/DefineRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/DefineRDBMSTableTestCaseIT.java
@@ -421,7 +421,6 @@ public class DefineRDBMSTableTestCaseIT {
         //Defining a RDBMS table without defining a value for username field.
         log.info("rdbmstabledefinitiontest11");
         SiddhiManager siddhiManager = new SiddhiManager();
-        String wrongUsernameRegex = "Wrong user name or password";
         String streams = "" +
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
@@ -436,7 +435,7 @@ public class DefineRDBMSTableTestCaseIT {
                 "insert into StockTable ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        LoggerCallBack loggerCallBack = new LoggerCallBack(wrongUsernameRegex) {
+        LoggerCallBack loggerCallBack = new LoggerCallBack(RDBMSTableTestUtils.wrongUsernameRegex) {
             @Override
             public void receive(String logEventMessage) {
                 isLogEventArrived = true;
@@ -446,7 +445,7 @@ public class DefineRDBMSTableTestCaseIT {
         siddhiAppRuntime.start();
         Thread.sleep(1000);
         Assert.assertEquals(isLogEventArrived, true,
-                "Matching log event not found for pattern: '" + wrongUsernameRegex + "'");
+                "Matching log event not found for pattern: '" + RDBMSTableTestUtils.wrongUsernameRegex + "'");
         LoggerAppender.setLoggerCallBack(null);
         siddhiAppRuntime.shutdown();
     }

--- a/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/JoinRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/JoinRDBMSTableTestCaseIT.java
@@ -665,4 +665,362 @@ public class JoinRDBMSTableTestCaseIT {
         siddhiAppRuntime.shutdown();
     }
 
+    @Test
+    public void testTableLeftOuterJoinQueryWithContainCondition() throws InterruptedException {
+        log.info("testTableLeftOuterJoinQueryWithContainCondition");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, volume long); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                //"@PrimaryKey(\"symbol\")" +
+                //"@Index(\"volume\")" +
+                "@connection(maxWait = '4000')" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream#window.length(1) left outer join StockTable " +
+                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "and StockTable.volume == CheckStockStream.volume " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
+                "StockTable.volume as volume  " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                Assert.assertEquals(event.getData(), new Object[]{"WSO2", "WSO2", 100L});
+                                break;
+                            case 2:
+                                Assert.assertEquals(event.getData(), new Object[]{"CSC", null, null});
+                                break;
+                            default:
+                                Assert.assertSame(inEventCount, 2);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 10L});
+        checkStockStream.send(new Object[]{"WSO2", 100L});
+        checkStockStream.send(new Object[]{"CSC", 20L});
+        Thread.sleep(1000);
+
+        Assert.assertEquals(inEventCount, 2, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        Assert.assertEquals(eventArrived, true, "Event arrived");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testTableRightOuterJoinQueryWithContainCondition() throws InterruptedException {
+        log.info("testTableRightOuterJoinQueryWithContainCondition");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, volume long); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                //"@PrimaryKey(\"symbol\")" +
+                //"@Index(\"volume\")" +
+                "@connection(maxWait = '4000')" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream#window.length(1) right outer join StockTable " +
+                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "and CheckStockStream.volume == StockTable.volume " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
+                "StockTable.volume as volume  " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                Assert.assertEquals(event.getData(), new Object[]{"WSO2", "WSO2", 100L});
+                                break;
+                            default:
+                                Assert.assertSame(inEventCount, 1);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 10L});
+        checkStockStream.send(new Object[]{"WSO2", 100L});
+        checkStockStream.send(new Object[]{"CSC", 60L});
+        Thread.sleep(1000);
+
+        Assert.assertEquals(inEventCount, 1, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        Assert.assertEquals(eventArrived, true, "Event arrived");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testTableFullOuterJoinQueryWithContainCondition() throws InterruptedException {
+        log.info("testTableFullOuterJoinQueryWithContainCondition");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, volume long); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                //"@PrimaryKey(\"symbol\")" +
+                //"@Index(\"volume\")" +
+                "@connection(maxWait = '4000')" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream#window.length(1) full outer join StockTable " +
+                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "and CheckStockStream.volume == StockTable.volume " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
+                "StockTable.volume as volume  " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                Assert.assertEquals(event.getData(), new Object[]{"WSO2", "WSO2", 100L});
+                                break;
+                            case 2:
+                                Assert.assertEquals(event.getData(), new Object[]{"CSC", null, null});
+                                break;
+                            default:
+                                Assert.assertSame(inEventCount, 2);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 10L});
+        checkStockStream.send(new Object[]{"WSO2", 100L});
+        checkStockStream.send(new Object[]{"CSC", 50L});
+        Thread.sleep(1000);
+
+        Assert.assertEquals(inEventCount, 2, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        Assert.assertEquals(eventArrived, true, "Event arrived");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testTableJoinQueryWithContainConditionAndConstantAsContainsValue() throws InterruptedException,
+            SQLException {
+        log.info("testTableJoinQueryWithContainConditionAndConstantAsContainsValue");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, price float); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                //"@PrimaryKey(\"symbol\")" +
+                //"@Index(\"volume\")" +
+                "@connection(maxWait = '4000')" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream#window.length(1) join StockTable " +
+                "on str:contain(StockTable.symbol, 'WSO2') " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
+                "StockTable.volume as volume  " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                Assert.assertEquals(event.getData(), new Object[]{"WSO2", "WSO2", 100L});
+                                break;
+                            case 2:
+                                Assert.assertEquals(event.getData(), new Object[]{"IBM", "WSO2", 100L});
+                                break;
+                            default:
+                                Assert.assertSame(inEventCount, 2);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM", 75.6f, 10L});
+        checkStockStream.send(new Object[]{"WSO2", 55.6f});
+        checkStockStream.send(new Object[]{"IBM", 75.6f});
+        Thread.sleep(1000);
+
+        Assert.assertEquals(inEventCount, 2, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        Assert.assertEquals(eventArrived, true, "Event arrived");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void testTableJoinQueryWithContainConditionAndFieldWithMultipleValues() throws InterruptedException,
+            SQLException {
+        log.info("testTableJoinQueryWithContainConditionAndFieldWithMultipleValues");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, price float); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                //"@PrimaryKey(\"symbol\")" +
+                //"@Index(\"volume\")" +
+                "@connection(maxWait = '4000')" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream#window.length(1) join StockTable " +
+                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
+                "StockTable.volume as volume  " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        switch (inEventCount) {
+                            case 1:
+                                Assert.assertEquals(event.getData(), new Object[]{"Colombo",
+                                        "WSO2, Palm Grove, Colombo", 100L});
+                                break;
+                            case 2:
+                                Assert.assertEquals(event.getData(), new Object[]{"United States",
+                                        "IBM, Armonk, New York, United States", 10L});
+                                break;
+                            default:
+                                Assert.assertSame(inEventCount, 2);
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2, Palm Grove, Colombo", 55.6f, 100L});
+        stockStream.send(new Object[]{"IBM, Armonk, New York, United States", 75.6f, 10L});
+        checkStockStream.send(new Object[]{"Colombo", 55.6f});
+        checkStockStream.send(new Object[]{"United States", 75.6f});
+        Thread.sleep(1000);
+
+        Assert.assertEquals(inEventCount, 2, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        Assert.assertEquals(eventArrived, true, "Event arrived");
+        siddhiAppRuntime.shutdown();
+    }
 }

--- a/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/JoinRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/JoinRDBMSTableTestCaseIT.java
@@ -686,7 +686,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "" +
                 "@info(name = 'query2') " +
                 "from CheckStockStream#window.length(1) left outer join StockTable " +
-                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "on str:contains(StockTable.symbol, CheckStockStream.symbol) " +
                 "and StockTable.volume == CheckStockStream.volume " +
                 "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
                 "StockTable.volume as volume  " +
@@ -758,7 +758,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "" +
                 "@info(name = 'query2') " +
                 "from CheckStockStream#window.length(1) right outer join StockTable " +
-                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "on str:contains(StockTable.symbol, CheckStockStream.symbol) " +
                 "and CheckStockStream.volume == StockTable.volume " +
                 "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
                 "StockTable.volume as volume  " +
@@ -827,7 +827,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "" +
                 "@info(name = 'query2') " +
                 "from CheckStockStream#window.length(1) full outer join StockTable " +
-                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "on str:contains(StockTable.symbol, CheckStockStream.symbol) " +
                 "and CheckStockStream.volume == StockTable.volume " +
                 "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
                 "StockTable.volume as volume  " +
@@ -900,7 +900,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "" +
                 "@info(name = 'query2') " +
                 "from CheckStockStream#window.length(1) join StockTable " +
-                "on str:contain(StockTable.symbol, 'WSO2') " +
+                "on str:contains(StockTable.symbol, 'WSO2') " +
                 "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
                 "StockTable.volume as volume  " +
                 "insert into OutputStream ;";
@@ -972,7 +972,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "" +
                 "@info(name = 'query2') " +
                 "from CheckStockStream#window.length(1) join StockTable " +
-                "on str:contain(StockTable.symbol, CheckStockStream.symbol) " +
+                "on str:contains(StockTable.symbol, CheckStockStream.symbol) " +
                 "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol, " +
                 "StockTable.volume as volume  " +
                 "insert into OutputStream ;";

--- a/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableTestUtils.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableTestUtils.java
@@ -39,11 +39,17 @@ public class RDBMSTableTestUtils {
 
     public static final String TABLE_NAME = "StockTable";
     private static final Logger log = Logger.getLogger(RDBMSTableTestUtils.class);
-    private static String connectionUrlMysql = "jdbc:mysql://{{container.ip}}:{{container.port}}/dasdb";
+    private static String connectionUrlMysql = "jdbc:mysql://{{container.ip}}:{{container.port}}/dasdb?useSSL=false";
     private static String connectionUrlPostgres = "jdbc:postgresql://{{container.ip}}:{{container.port}}/dasdb";
     private static String connectionUrlOracle = "jdbc:oracle:thin:@{{container.ip}}:{{container.port}}/XE";
     private static String connectionUrlMsSQL = "jdbc:sqlserver://{{container.ip}}:{{container.port}};" +
             "databaseName=tempdb";
+    private static final String WRONG_USER_NAME_REGEX_MYSQL = "Access denied for user";
+    private static final String WRONG_USER_NAME_REGEX_ORACLE = "invalid username/password; logon denied";
+    private static final String WRONG_USER_NAME_REGEX_H2 = "Wrong user name or password";
+    private static final String WRONG_USER_NAME_REGEX_POSTGRES = "password authentication failed";
+    private static final String WRONG_USER_NAME_REGEX_MSSQL = "Login failed for user";
+    private static final String WRONG_USER_NAME_REGEX_DB2 = "Connection authorization failure occurred";
     private static String connectionUrlDB2 = "jdbc:db2://{{container.ip}}:{{container.port}}/SAMPLE";
     private static final String CONNECTION_URL_H2 = "jdbc:h2:./target/dasdb";
     private static final String JDBC_DRIVER_CLASS_NAME_H2 = "org.h2.Driver";
@@ -60,6 +66,7 @@ public class RDBMSTableTestUtils {
     public static String user = USERNAME;
     public static String password = PASSWORD;
     private static DataSource testDataSource;
+    public static String wrongUsernameRegex = WRONG_USER_NAME_REGEX_H2;
 
     private RDBMSTableTestUtils() {
 
@@ -91,32 +98,38 @@ public class RDBMSTableTestUtils {
                 url = connectionUrlMysql.replace("{{container.ip}}", getIpAddressOfContainer()).
                         replace("{{container.port}}", port);
                 driverClassName = JDBC_DRIVER_CLASS_NAME_MYSQL;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_MYSQL;
                 break;
             case H2:
                 url = CONNECTION_URL_H2;
                 driverClassName = JDBC_DRIVER_CLASS_NAME_H2;
                 user = USERNAME;
                 password = PASSWORD;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_H2;
                 break;
             case POSTGRES:
                 url = connectionUrlPostgres.replace("{{container.ip}}", getIpAddressOfContainer()).
                         replace("{{container.port}}", port);
                 driverClassName = JDBC_DRIVER_CLASS_POSTGRES;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_POSTGRES;
                 break;
             case ORACLE:
                 url = connectionUrlOracle.replace("{{container.ip}}", getIpAddressOfContainer()).
                         replace("{{container.port}}", port);
                 driverClassName = JDBC_DRIVER_CLASS_NAME_ORACLE;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_ORACLE;
                 break;
             case MSSQL:
                 url = connectionUrlMsSQL.replace("{{container.ip}}", getIpAddressOfContainer()).
                         replace("{{container.port}}", port);
                 driverClassName = JDBC_DRIVER_CLASS_MSSQL;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_MSSQL;
                 break;
             case DB2:
                 url = connectionUrlDB2.replace("{{container.ip}}", getIpAddressOfContainer()).
                         replace("{{container.port}}", port);
                 driverClassName = JDBC_DRIVER_CLASS_DB2;
+                wrongUsernameRegex = WRONG_USER_NAME_REGEX_DB2;
                 break;
         }
         log.info("URL of docker instance: " + url);

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,8 @@
     </profiles>
 
     <properties>
-        <siddhi.version>4.2.0</siddhi.version>
+        <siddhi.version>4.2.5</siddhi.version>
+        <siddhi.execution.string.version>4.0.20</siddhi.execution.string.version>
         <log4j.version>1.2.17.wso2v1</log4j.version>
         <testng.version>6.9.10</testng.version>
         <hikari.version>2.6.1</hikari.version>
@@ -502,6 +503,12 @@
             <artifactId>siddhi-store-rdbms-tests-distribution</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.extension.siddhi.execution.string</groupId>
+            <artifactId>siddhi-execution-string</artifactId>
+            <version>${siddhi.execution.string.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -504,12 +504,6 @@
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>
-        <dependency>
-            <groupId>org.wso2.extension.siddhi.execution.string</groupId>
-            <artifactId>siddhi-execution-string</artifactId>
-            <version>${siddhi.execution.string.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
> Current RDBMS table join on condition only support exact match on the table field value, but RDBMS support SQL clause 'LIKE' to match the part of the string in the table field.

e.g.
User Table
**|User Roles|Tenant ID|App Name|**
|admin, user, manager|-1234|Admin_APP|

In the above example, with this new feature user can matches the user 'admin' in 'User Roles' field and get the matching record.

## Goals
> Add new feature to RDBMS store to support string contain check on a table field as a join condition. 

## Approach
> Modify the RDBMS store find() method to compile the str:contain check and format SQL query with LIKE clause based on the contains conditional values.

## Release note
> Adding contains check feature in RDBMS store

## Documentation
> N/A - documentation added by the annotations

## Automation tests
 - Unit tests 
   OSGI Test Added

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Sample added as store annotation doc.

## Test environment
> H2, MYSQL, POSTGRES, ORACLE, MSSQL and DB2