### PR TITLE
Fix https://github.com/wso2-extensions/siddhi-store-rdbms/issues/99.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -400,7 +400,6 @@ public class RDBMSEventTable extends AbstractRecordTable {
     private String stringType;
     private String stringSize;
     private String recordContainsConditionTemplate;
-    private String findCondition;
 
     @Override
     protected void init(TableDefinition tableDefinition, ConfigReader configReader) {
@@ -439,13 +438,12 @@ public class RDBMSEventTable extends AbstractRecordTable {
     protected RecordIterator<Object[]> find(Map<String, Object> findConditionParameterMap,
                                             CompiledCondition compiledCondition) {
         RDBMSCompiledCondition rdbmsCompiledCondition = (RDBMSCompiledCondition) compiledCondition;
-        if (findCondition == null) {
-            if (rdbmsCompiledCondition.isContainsConditionExist()) {
-                findCondition = RDBMSTableUtils.processFindConditionWithContainsConditionTemplate(
-                        rdbmsCompiledCondition.getCompiledQuery(), this.recordContainsConditionTemplate);
-            } else {
-                findCondition = rdbmsCompiledCondition.getCompiledQuery();
-            }
+        String findCondition;
+        if (rdbmsCompiledCondition.isContainsConditionExist()) {
+            findCondition = RDBMSTableUtils.processFindConditionWithContainsConditionTemplate(
+                    rdbmsCompiledCondition.getCompiledQuery(), this.recordContainsConditionTemplate);
+        } else {
+            findCondition = rdbmsCompiledCondition.getCompiledQuery();
         }
         //Some databases does not support single condition on where clause.
         //(atomic condition on where clause: SELECT * FROM TABLE WHERE true)


### PR DESCRIPTION
## Purpose
Fix #99 

## Approach
Make `findCondition` a method variable. 

Currently `findCondition` is a class variable which gets initialized only the first time find() is called.
This way, when there are multiple queries using the same rdbms store, all the queries will have the same `findCondition` which gives the error being reported. 
 
Performance wise it would be better if we could make `findCondition` a class variable and resue it (not build it in every find() call). We will have to figure out a way to do that. 

## User stories
N/A as this is a bug fix.