### PR TITLE
Add support to pass parameterised queries for rdbms:query and rdbms:cud functions

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
@@ -68,6 +68,12 @@ import java.util.Map;
                         description = "The update, delete, or insert query(formatted according to " +
                                 "the relevant database type) that needs to be performed.",
                         type = DataType.STRING
+                ),
+                @Parameter(
+                        name = "parameterN",
+                        description = "If the second parameter is a parametrised SQL query, then siddhi attributes " +
+                                "can be passed to set the values of the parameters",
+                        type = DataType.STRING
                 )
         },
         systemParameter = {
@@ -96,6 +102,17 @@ import java.util.Map;
                                 "with an additional attribute named 'numRecords', of which the value indicates the" +
                                 " number of records manipulated. The updated events are inserted into an output " +
                                 "stream named 'RecordStream'."
+                ),
+                @Example(
+                        syntax = "from TriggerStream#rdbms:cud(\"SAMPLE_DB\", \"UPDATE Customers_Table SET " +
+                                "customerName=? where customerName=?\", changedName, previousName) \n" +
+                                "select numRecords \n" +
+                                "insert into  RecordStream;",
+                        description = "This query updates the events from the input stream named 'TriggerStream' " +
+                                "with an additional attribute named 'numRecords', of which the value indicates the" +
+                                " number of records manipulated. The updated events are inserted into an output " +
+                                "stream named 'RecordStream'. Here the values of attributes changedName and " +
+                                "previousName in the event will be set to the query."
                 )
         }
 )

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
@@ -70,7 +70,7 @@ import java.util.Map;
                         type = DataType.STRING
                 ),
                 @Parameter(
-                        name = "parameterN",
+                        name = "parameter.n",
                         description = "If the second parameter is a parametrised SQL query, then siddhi attributes " +
                                 "can be passed to set the values of the parameters",
                         type = DataType.STRING

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
@@ -118,15 +118,18 @@ public class QueryStreamProcessor extends StreamProcessor {
     private HikariDataSource dataSource;
     private ExpressionExecutor queryExpressionExecutor;
     private List<Attribute> attributeList = new ArrayList<>();
+    private boolean isVaryingQuery;
+    private List<ExpressionExecutor> expressionExecutors = new ArrayList<>();
 
     @Override
     protected List<Attribute> init(AbstractDefinition inputDefinition,
                                    ExpressionExecutor[] attributeExpressionExecutors, ConfigReader configReader,
                                    SiddhiAppContext siddhiAppContext) {
 
-        if ((attributeExpressionExecutors.length != 3)) {
-            throw new SiddhiAppValidationException("rdbms query function  should have 3 parameters , but found '" +
-                    attributeExpressionExecutors.length + "' parameters.");
+        int attributesLength = attributeExpressionExecutors.length;
+        if ((attributesLength < 3)) {
+            throw new SiddhiAppValidationException("rdbms query function  should have at least 3 parameters , " +
+                    "but found '" + attributesLength + "' parameters.");
         }
 
         this.dataSourceName = RDBMSStreamProcessorUtil.validateDatasourceName(attributeExpressionExecutors[0]);
@@ -139,8 +142,35 @@ public class QueryStreamProcessor extends StreamProcessor {
                     attributeExpressionExecutors[1].getReturnType() + "'.");
         }
 
-        if (attributeExpressionExecutors[2] instanceof ConstantExpressionExecutor) {
-            String attributeDefinition = ((ConstantExpressionExecutor) attributeExpressionExecutors[2])
+        ExpressionExecutor streamDefExecutor;
+        if (attributesLength == 3) {
+            streamDefExecutor = attributeExpressionExecutors[2];
+            this.isVaryingQuery = false;
+        } else {
+            this.isVaryingQuery = true;
+            //Process the query conditions through stream attributes
+            long attributeCount;
+            if (queryExpressionExecutor instanceof ConstantExpressionExecutor) {
+                String query = ((ConstantExpressionExecutor) queryExpressionExecutor).getValue().toString();
+                attributeCount = query.chars().filter(ch -> ch == '?').count();
+            } else {
+                throw new SiddhiAppValidationException("The parameter 'query' in rdbms query " +
+                        "function should be a constant, but found a parameter of instance '" +
+                        attributeExpressionExecutors[1].getClass().getName() + "'.");
+            }
+            if (attributeCount == attributesLength - 3) {
+                this.expressionExecutors.addAll(
+                        Arrays.asList(attributeExpressionExecutors).subList(2, attributesLength - 1));
+            } else {
+                throw new SiddhiAppValidationException("The parameter 'query' in rdbms query " +
+                        "function contains '" + attributeCount + "' ordinals, but found siddhi attributes of count '" +
+                        (attributesLength - 3) + "'.");
+            }
+            streamDefExecutor = attributeExpressionExecutors[attributesLength - 1];
+        }
+
+        if (streamDefExecutor instanceof ConstantExpressionExecutor) {
+            String attributeDefinition = ((ConstantExpressionExecutor) streamDefExecutor)
                     .getValue().toString();
             this.attributeList = Arrays.stream(attributeDefinition.split(","))
                     .map((String attributeExp) -> {
@@ -181,7 +211,7 @@ public class QueryStreamProcessor extends StreamProcessor {
         } else {
             throw new SiddhiAppValidationException("The parameter 'query' in rdbms query function should be a " +
                     "constant, but found a dynamic attribute of type '" +
-                    attributeExpressionExecutors[1].getClass().getCanonicalName() + "'.");
+                    queryExpressionExecutor.getClass().getCanonicalName() + "'.");
         }
     }
 
@@ -201,6 +231,14 @@ public class QueryStreamProcessor extends StreamProcessor {
                             "'" + query + "'. Event: '" + event + "'.");
                 }
                 stmt = conn.prepareStatement(query);
+                if (isVaryingQuery) {
+                    for (int i = 0; i < this.expressionExecutors.size(); i++) {
+                        ExpressionExecutor attributeExpressionExecutor = this.expressionExecutors.get(i);
+                        RDBMSStreamProcessorUtil.populateStatementWithSingleElement(stmt, i + 1,
+                                attributeExpressionExecutor.getReturnType(),
+                                attributeExpressionExecutor.execute(event));
+                    }
+                }
                 resultSet = stmt.executeQuery();
                 while (resultSet.next()) {
                     StreamEvent clonedEvent = streamEventCloner.copyStreamEvent(event);

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
@@ -71,7 +71,7 @@ import java.util.stream.Collectors;
                         type = DataType.STRING
                 ),
                 @Parameter(
-                        name = "parameterN",
+                        name = "parameter.n",
                         description = "If the second parameter is a parametrised SQL query, then siddhi attributes " +
                                 "can be passed to set the values of the parameters",
                         type = DataType.STRING

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
@@ -71,6 +71,12 @@ import java.util.stream.Collectors;
                         type = DataType.STRING
                 ),
                 @Parameter(
+                        name = "parameterN",
+                        description = "If the second parameter is a parametrised SQL query, then siddhi attributes " +
+                                "can be passed to set the values of the parameters",
+                        type = DataType.STRING
+                ),
+                @Parameter(
                         name = "attribute.definition.list",
                         description = "This is provided as a comma-separated list in the " +
                                 "'<AttributeName AttributeType>' format. " +
@@ -110,6 +116,19 @@ import java.util.stream.Collectors;
                                 "i.e an event will be generated for each record retrieved from the datasource. " +
                                 "The event will include as additional attributes, the attributes defined in the " +
                                 "`attribute.definition.list`(creditcardno, country, transaction, amount)."
+                ),
+                @Example(
+                        syntax = "from TriggerStream#rdbms:query('SAMPLE_DB', 'select * from " +
+                                "where country=? ', countrySearchWord, 'creditcardno string, country string, " +
+                                "transaction string, amount int') \n" +
+                                "select creditcardno, country, transaction, amount \n" +
+                                "insert into recordStream;",
+                        description = "Events inserted into recordStream includes all records matched for the query " +
+                                "i.e an event will be generated for each record retrieved from the datasource. " +
+                                "The event will include as additional attributes, the attributes defined in the " +
+                                "`attribute.definition.list`(creditcardno, country, transaction, amount). " +
+                                "countrySearchWord value from the event will be set in the query when querying the " +
+                                "datasource."
                 )
         }
 )

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
@@ -32,6 +32,7 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.exception.SiddhiAppValidationException;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -200,6 +201,43 @@ public class RDBMSStreamProcessorUtil {
         } catch (DataSourceException e) {
             throw new SiddhiAppRuntimeException("Datasource '" + dataSourceName + "' cannot be " +
                     "connected.", e);
+        }
+    }
+
+    /**
+     * Util method which is used to populate a {@link PreparedStatement} instance with a single element.
+     *
+     * @param stmt    the statement to which the element should be set.
+     * @param ordinal the ordinal of the element in the statement (its place in a potential list of places).
+     * @param type    the type of the element to be set, adheres to
+     *                {@link org.wso2.siddhi.query.api.definition.Attribute.Type}.
+     * @param value   the value of the element.
+     * @throws SQLException if there are issues when the element is being set.
+     */
+    public static void populateStatementWithSingleElement(PreparedStatement stmt, int ordinal, Attribute.Type type,
+                                                          Object value) throws SQLException {
+        switch (type) {
+            case BOOL:
+                stmt.setBoolean(ordinal, (Boolean) value);
+                break;
+            case DOUBLE:
+                stmt.setDouble(ordinal, (Double) value);
+                break;
+            case FLOAT:
+                stmt.setFloat(ordinal, (Float) value);
+                break;
+            case INT:
+                stmt.setInt(ordinal, (Integer) value);
+                break;
+            case LONG:
+                stmt.setLong(ordinal, (Long) value);
+                break;
+            case OBJECT:
+                stmt.setObject(ordinal, value);
+                break;
+            case STRING:
+                stmt.setString(ordinal, (String) value);
+                break;
         }
     }
 }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -19,9 +19,10 @@
 
 <FindBugsFilter>
     <!-- SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING : SQL statement will different for each event -->
+    <!-- NP_LOAD_OF_KNOWN_NULL_VALUE: Null is checked at the connection clean up util class-->
     <Match>
         <Class name="org.wso2.extension.siddhi.store.rdbms.RDBMSEventTable"/>
-        <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING"/>
+        <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING, NP_LOAD_OF_KNOWN_NULL_VALUE"/>
     </Match>
     <!-- PZLA_PREFER_ZERO_LENGTH_ARRAYS: Iterator should always return a constant size array, that's why null returned
     at exception -->


### PR DESCRIPTION
## Purpose
As of now, rdbms:query() function can be called with the following syntax.
rdbms:query('CARBON_DB', select symbol, price from stockTable where symbol =='WSO2', 'symbol string, price float')
However, if the query changes as per the trigger stream attribute, then the query must be created before this function is called within a temp stream.

The improvement is to have the following syntax.
rdbms:query('CARBON_DB', select symbol, price from stockTable where symbol ==?', symbol, 'symbol string, price float')
rdbms:query(<datasource>, <SQL query with ?>, <Attributes...>?, <stream definition>)
This will improve the usability of the function.

Fixes https://github.com/wso2-extensions/siddhi-store-rdbms/issues/105

## Goals
Add support to pass parameterised queries for rdbms:query and rdbms:cud functions

## Approach
108463c

## User stories
N/A

## Documentation
Annotations updated in the PR itself

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes/
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
