### PR TITLE
Fix the result set not close issue[Cursor leak] in Query Stream Processor

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
@@ -209,6 +209,7 @@ public class QueryStreamProcessor extends StreamProcessor {
                     streamEventChunk.insertBeforeCurrent(clonedEvent);
                 }
                 streamEventChunk.remove();
+                RDBMSStreamProcessorUtil.cleanupConnection(resultSet, null, null);
             }
             nextProcessor.process(streamEventChunk);
         } catch (SQLException e) {


### PR DESCRIPTION
## Purpose
> The purpose of this PR is to fix the result set not closing issue in Query Stream Processor extension. 

## Goals
> Fix the Cursor leak issue: https://github.com/wso2-extensions/siddhi-store-rdbms/issues/119 in Query Stream Processor

## Approach
> Close the result set after finishing the iteration

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A