### PR TITLE
Improve the handling of connection breaks.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -1412,7 +1412,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
      *
      * @return a new {@link Connection} instance from the datasource.
      */
-    private Connection getConnection() {
+    private Connection getConnection() throws ConnectionUnavailableException {
         return this.getConnection(true);
     }
 
@@ -1422,13 +1422,14 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
      * @param autoCommit whether or not transactions to the connections should be committed automatically.
      * @return a new {@link Connection} instance from the datasource.
      */
-    private Connection getConnection(boolean autoCommit) {
+    private Connection getConnection(boolean autoCommit) throws ConnectionUnavailableException {
         Connection conn;
         try {
             conn = this.dataSource.getConnection();
             conn.setAutoCommit(autoCommit);
         } catch (SQLException e) {
-            throw new RDBMSTableException("Error initializing connection: " + e.getMessage(), e);
+            throw new ConnectionUnavailableException("Error initializing connection for store: " + tableName +
+                    ". Reason: " + e.getMessage(), e);
         }
         return conn;
     }
@@ -1645,7 +1646,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
      *
      * @return true/false based on the table existence.
      */
-    private boolean tableExists() {
+    private boolean tableExists() throws ConnectionUnavailableException {
         Connection conn = this.getConnection();
         PreparedStatement stmt = null;
         ResultSet rs = null;


### PR DESCRIPTION
## Purpose
Improving the handling of connection breaks.

## Goals
Make sure RDBMS Store reconnects after connection failure. 

## Approach
If an `SQLException` occurs while performing a DB operation, it is checked whether the connection is still valid. If the connection is not valid, a `ConnectionUnavailableException` is thrown. Otherwise `RDBMSTableException` is thrown. 

## Release note
Improving the handling of connection breaks in RDBMS Store. 

## Documentation
N/A as this is an improvement invisble to the user.

## Automation tests
 - Unit tests 
   > All existing tests are passing
 - Integration tests
   > All existing tests are passing

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Migrations (if applicable)
N/A

## Test environment
java version  1.8.0_171-b11
 
