### PR TITLE
 Modify the table creation execution path when table is exists

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -636,7 +636,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 RDBMSTableUtils.cleanupConnection(null, stmt, conn);
                 if (!isConnValid) {
                     throw new ConnectionUnavailableException("Connection closed. Error retrieving records from store '"
-                            + this.tableName + "'" , e);
+                            + this.tableName + "'", e);
                 } else {
                     throw new RDBMSTableException("Error retrieving records from store '" + this.tableName + "'", e);
                 }
@@ -1515,7 +1515,14 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 log.debug("Table '" + this.tableName + "' created.");
             }
         } catch (RDBMSTableException e) {
-            throw new RDBMSTableException("Unable to initialize table '" + this.tableName + "'", e);
+            if (e.getCause().getMessage().toLowerCase().contains("already exists")) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Table exist with the name " + tableName + ". Existing table will be used ");
+                }
+            } else {
+                throw new RDBMSTableException("Unable to initialize table '" + this.tableName +
+                        "': " + e.getMessage(), e);
+            }
         }
     }
 

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -1515,7 +1515,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 log.debug("Table '" + this.tableName + "' created.");
             }
         } catch (RDBMSTableException e) {
-            if (e.getCause().getMessage().toLowerCase().contains("already exists")) {
+            if (e.getCause() != null && e.getCause().getMessage().toLowerCase().contains("already exists")) {
                 if (log.isDebugEnabled()) {
                     log.debug("Table exist with the name " + tableName + ". Existing table will be used ");
                 }

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -1520,8 +1520,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                     log.debug("Table exist with the name " + tableName + ". Existing table will be used ");
                 }
             } else {
-                throw new RDBMSTableException("Unable to initialize table '" + this.tableName +
-                        "': " + e.getMessage(), e);
+                throw new RDBMSTableException("Unable to initialize table '" + this.tableName + "'", e);
             }
         }
     }


### PR DESCRIPTION
## Purpose
> This will ignore the error which throws when there is a table with the same name that tries to create.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
> Oracle JDK 1.8.0_144
