### PR TITLE
Fix store query limit issues for mssql

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -505,8 +505,8 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
 public class RDBMSEventTable extends AbstractQueryableRecordTable {
 
     private static final Log log = LogFactory.getLog(RDBMSEventTable.class);
-    private String selectNullClause = "(SELECT NULL)";
-    public static final String ZERO = "0";
+    private static final  String SELECT_NULL = "(SELECT NULL)";
+    private static final String ZERO = "0";
     private RDBMSQueryConfigurationEntry queryConfigurationEntry;
     private HikariDataSource dataSource;
     private boolean isLocalDatasource;
@@ -1888,11 +1888,11 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                                 "'isLimitBeforeOffset' has not being configured in RDBMS Event Table query " +
                                 "configuration, for store: " + tableName);
                     }
-                    if (queryConfigurationEntry.getDatabaseName().equals(RDBMSTableConstants.MICROSOFT_SQL_SERVER_NAME)
-                            && compiledOrderByClause == null) {
+                    if (queryConfigurationEntry.getDatabaseName().equalsIgnoreCase(
+                            RDBMSTableConstants.MICROSOFT_SQL_SERVER_NAME) && compiledOrderByClause == null) {
                         String orderByClause = rdbmsSelectQueryTemplate.getOrderByClause();
                         orderByClause = orderByClause.replace(
-                                RDBMSTableConstants.PLACEHOLDER_COLUMNS, selectNullClause);
+                                RDBMSTableConstants.PLACEHOLDER_COLUMNS, SELECT_NULL);
                         selectQuery = selectQuery.append(WHITESPACE).append(orderByClause);
                     }
                     if (isLimitBeforeOffset) {
@@ -1903,13 +1903,12 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                                 .append(WHITESPACE).append(limitClause);
                     }
                 } else {
-                    if (queryConfigurationEntry.getDatabaseName().equals(
+                    if (queryConfigurationEntry.getDatabaseName().equalsIgnoreCase(
                             RDBMSTableConstants.MICROSOFT_SQL_SERVER_NAME)) {
                         if (compiledOrderByClause == null) {
                             String orderByClause = rdbmsSelectQueryTemplate.getOrderByClause();
-//                            selectNullClause = selectNullClause.replace(TABLE_NAME, tableName);
                             orderByClause = orderByClause.replace(
-                                    RDBMSTableConstants.PLACEHOLDER_COLUMNS, selectNullClause);
+                                    RDBMSTableConstants.PLACEHOLDER_COLUMNS, SELECT_NULL);
                             selectQuery = selectQuery.append(WHITESPACE).append(orderByClause);
                         }
                         String offsetClause = rdbmsSelectQueryTemplate.getOffsetClause();

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/RDBMSEventTable.java
@@ -505,6 +505,8 @@ import static org.wso2.siddhi.core.util.SiddhiConstants.ANNOTATION_STORE;
 public class RDBMSEventTable extends AbstractQueryableRecordTable {
 
     private static final Log log = LogFactory.getLog(RDBMSEventTable.class);
+    private String selectNullClause = "(SELECT NULL)";
+    public static final String ZERO = "0";
     private RDBMSQueryConfigurationEntry queryConfigurationEntry;
     private HikariDataSource dataSource;
     private boolean isLocalDatasource;
@@ -1886,6 +1888,13 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                                 "'isLimitBeforeOffset' has not being configured in RDBMS Event Table query " +
                                 "configuration, for store: " + tableName);
                     }
+                    if (queryConfigurationEntry.getDatabaseName().equals(RDBMSTableConstants.MICROSOFT_SQL_SERVER_NAME)
+                            && compiledOrderByClause == null) {
+                        String orderByClause = rdbmsSelectQueryTemplate.getOrderByClause();
+                        orderByClause = orderByClause.replace(
+                                RDBMSTableConstants.PLACEHOLDER_COLUMNS, selectNullClause);
+                        selectQuery = selectQuery.append(WHITESPACE).append(orderByClause);
+                    }
                     if (isLimitBeforeOffset) {
                         selectQuery = selectQuery.append(WHITESPACE).append(limitClause)
                                 .append(WHITESPACE).append(offsetClause);
@@ -1894,7 +1903,29 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                                 .append(WHITESPACE).append(limitClause);
                     }
                 } else {
-                    selectQuery = selectQuery.append(WHITESPACE).append(limitClause);
+                    if (queryConfigurationEntry.getDatabaseName().equals(
+                            RDBMSTableConstants.MICROSOFT_SQL_SERVER_NAME)) {
+                        if (compiledOrderByClause == null) {
+                            String orderByClause = rdbmsSelectQueryTemplate.getOrderByClause();
+//                            selectNullClause = selectNullClause.replace(TABLE_NAME, tableName);
+                            orderByClause = orderByClause.replace(
+                                    RDBMSTableConstants.PLACEHOLDER_COLUMNS, selectNullClause);
+                            selectQuery = selectQuery.append(WHITESPACE).append(orderByClause);
+                        }
+                        String offsetClause = rdbmsSelectQueryTemplate.getOffsetClause();
+                        offsetClause = offsetClause.replace(RDBMSTableConstants.PLACEHOLDER_Q, ZERO);
+                        Boolean isLimitBeforeOffset = Boolean.parseBoolean(rdbmsSelectQueryTemplate.
+                                getIsLimitBeforeOffset());
+                        if (isLimitBeforeOffset) {
+                            selectQuery = selectQuery.append(WHITESPACE).append(limitClause)
+                                    .append(WHITESPACE).append(offsetClause);
+                        } else {
+                            selectQuery = selectQuery.append(WHITESPACE).append(offsetClause)
+                                    .append(WHITESPACE).append(limitClause);
+                        }
+                    } else {
+                        selectQuery = selectQuery.append(WHITESPACE).append(limitClause);
+                    }
                 }
             }
             return selectQuery.toString();

--- a/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/store/rdbms/util/RDBMSTableConstants.java
@@ -121,6 +121,7 @@ public class RDBMSTableConstants {
     public static final String QUERY_WRAPPER_CLAUSE = "queryWrapperClause";
     public static final String LIMIT_WRAPPER_CLAUSE = "limitWrapperClause";
     public static final String OFFSET_WRAPPER_CLAUSE = "offsetWrapperClause";
+    public static final String MICROSOFT_SQL_SERVER_NAME = "Microsoft SQL Server";
 
     private RDBMSTableConstants() {
         //preventing initialization

--- a/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/query/StoreQueryTableTestCaseIT.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/store/rdbms/query/StoreQueryTableTestCaseIT.java
@@ -489,7 +489,8 @@ public class StoreQueryTableTestCaseIT {
                 "on price > 53 " +
                 "select symbol, price, sum(volume) as totalVolume, avg(volume) as avgVolume, " +
                 "min(volume) as minVolume, max(volume) as maxVolume " +
-                "group by symbol, price ";
+                "group by symbol, price "
+                + "order by price desc";
         Event[] events = siddhiAppRuntime.query(storeQuery);
         EventPrinter.print(events);
         AssertJUnit.assertEquals(2, events.length);


### PR DESCRIPTION
## Purpose
$Subject

## Approach
Queries in rdbms-config doesn't work as it is for store queries with limit functionality in mssql as it mandate order by and offset for using fetch. Hence query creation logic is altered only for mssql by checking queryConfigurationEntry.getDatabaseName() to be equal to" Microsoft SQL Server". After the check mandatory fields are added with default values. Ex : order by (select null) offset 0

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
