### PR TITLE
Add support for incrementalAggregator:last() function for aggregation select optimisation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ language: java
 
 services:
   - docker
+  
+before_install:
+  # Load cached docker images
+  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
 
 install: true
 
@@ -42,6 +46,16 @@ jobs:
       before_script:
         - cd tests/osgi-tests/
       script: mvn verify
+      
+
+before_cache:
+  # Save tagged docker images
+  - >
+    mkdir -p $HOME/docker && docker images -a --filter='dangling=false' --format '{{.Repository}}:{{.Tag}} {{.ID}}'
+    | xargs -n 2 -t sh -c 'test -e $HOME/docker/$1.tar.gz || docker save $0 | gzip -2 > $HOME/docker/$1.tar.gz'
+      
 cache:
+  bundler: true
   directories:
+    - $HOME/docker
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ services:
   - docker
   
 before_install:
-  # Load cached docker images
-  - if [[ -d $HOME/docker ]]; then ls $HOME/docker/*.tar.gz | xargs -I {file} sh -c "zcat {file} | docker load"; fi
+  # Load cached docker image only if needed
+  - echo "$DOCKER_IMAGE"
+  - >
+    if [[ -d $HOME/docker ]] && [[ ! -z "$DOCKER_IMAGE" ]]; then for file in $HOME/docker/*; do
+    if [[ ${file##*/} == $DOCKER_IMAGE* ]]; then sh -c "docker load -i $file;"; fi done; fi
 
 install: true
 
@@ -34,12 +37,18 @@ jobs:
       script: mvn verify -P local-h2 -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
     - stage: test
       name: MySQL
+      env:
+        - DOCKER_IMAGE=mysql
       script: mvn verify -P local-mysql -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
     - stage: test
       name: MSSQL
+      env:
+        - DOCKER_IMAGE=microsoft
       script: mvn verify -P local-mssql -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
     - stage: test
       name: postgres
+      env:
+        - DOCKER_IMAGE=postgres
       script: mvn verify -P local-postgres -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
     - stage: test
       name: OSGi-test

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ database according to the given profile before execute the test suit.
             
     * Oracle 11.2.0.2 Express Edition:
             
-             mvn verify -P local-oracle12 -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
+             mvn verify -P local-oracle -f component/pom.xml -Dskip.surefire.test=true -Ddocker.removeVolumes=true
              
     * Oracle 12.1.0.2 Standard Edition:
          

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -253,20 +253,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>run-oracle</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>mvn</executable>
-                                    <arguments>
-                                        <argument>verify</argument>
-                                        <argument>-P local-oracle</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>run-mssql</id>
                                 <phase>integration-test</phase>
                                 <goals>
@@ -277,6 +263,20 @@
                                     <arguments>
                                         <argument>verify</argument>
                                         <argument>-P local-mssql</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>run-oracle</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>mvn</executable>
+                                    <arguments>
+                                        <argument>verify</argument>
+                                        <argument>-P local-oracle</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -513,7 +513,7 @@
                             <images>
                                 <image>
                                     <alias>siddhi-rdbms-mysql</alias>
-                                    <name>mysql:5.7</name>
+                                    <name>mysql:5.7.26</name>
                                     <run>
                                         <namingStrategy>alias</namingStrategy>
                                         <env>

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -239,20 +239,6 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>run-postgres</id>
-                                <phase>integration-test</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>mvn</executable>
-                                    <arguments>
-                                        <argument>verify</argument>
-                                        <argument>-P local-postgres</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                            <execution>
                                 <id>run-mssql</id>
                                 <phase>integration-test</phase>
                                 <goals>
@@ -263,6 +249,20 @@
                                     <arguments>
                                         <argument>verify</argument>
                                         <argument>-P local-mssql</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>run-postgres</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>mvn</executable>
+                                    <arguments>
+                                        <argument>verify</argument>
+                                        <argument>-P local-postgres</argument>
                                     </arguments>
                                 </configuration>
                             </execution>
@@ -1042,7 +1042,7 @@
                                         </ports>
                                         <wait>
                                             <log>DATABASE IS READY TO USE!</log>
-                                            <time>400000</time>
+                                            <time>600000</time>
                                         </wait>
                                         <shmSize>2718281829</shmSize>
                                     </run>

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSCompiledCondition.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSCompiledCondition.java
@@ -28,16 +28,24 @@ import java.util.SortedMap;
 public class RDBMSCompiledCondition implements CompiledCondition {
 
     private String compiledQuery;
+    private boolean isLatestConditionExist;
+    private String innerQuerySelectors;
+    private String outerCompiledCondition;
     private SortedMap<Integer, Object> parameters;
     private boolean isContainsConditionExist;
     private int ordinalOfContainPattern;
 
     public RDBMSCompiledCondition(String compiledQuery, SortedMap<Integer, Object> parameters,
-                                  boolean isContainsConditionExist, int ordinalOfContainPattern) {
+                                  boolean isContainsConditionExist, int ordinalOfContainPattern,
+                                  boolean isLatestConditionExist, String innerQuerySelectors,
+                                  String outerCompiledCondition) {
         this.compiledQuery = compiledQuery;
         this.parameters = parameters;
         this.isContainsConditionExist = isContainsConditionExist;
         this.ordinalOfContainPattern = ordinalOfContainPattern;
+        this.isLatestConditionExist = isLatestConditionExist;
+        this.innerQuerySelectors = innerQuerySelectors;
+        this.outerCompiledCondition = outerCompiledCondition;
     }
 
     public String getCompiledQuery() {
@@ -46,6 +54,18 @@ public class RDBMSCompiledCondition implements CompiledCondition {
 
     public boolean isContainsConditionExist() {
         return isContainsConditionExist;
+    }
+
+    public boolean isLatestConditionExist() {
+        return isLatestConditionExist;
+    }
+
+    public String getInnerQuerySelectors() {
+        return innerQuerySelectors;
+    }
+
+    public String getOuterCompiledCondition() {
+        return outerCompiledCondition;
     }
 
     public String toString() {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSCompiledCondition.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSCompiledCondition.java
@@ -28,8 +28,8 @@ import java.util.SortedMap;
 public class RDBMSCompiledCondition implements CompiledCondition {
 
     private String compiledQuery;
-    private boolean isLatestConditionExist;
-    private String innerQuerySelectors;
+    private boolean useSubSelect;
+    private String subSelectQuerySelectors;
     private String outerCompiledCondition;
     private SortedMap<Integer, Object> parameters;
     private boolean isContainsConditionExist;
@@ -37,14 +37,14 @@ public class RDBMSCompiledCondition implements CompiledCondition {
 
     public RDBMSCompiledCondition(String compiledQuery, SortedMap<Integer, Object> parameters,
                                   boolean isContainsConditionExist, int ordinalOfContainPattern,
-                                  boolean isLatestConditionExist, String innerQuerySelectors,
+                                  boolean useSubSelect, String subSelectQuerySelectors,
                                   String outerCompiledCondition) {
         this.compiledQuery = compiledQuery;
         this.parameters = parameters;
         this.isContainsConditionExist = isContainsConditionExist;
         this.ordinalOfContainPattern = ordinalOfContainPattern;
-        this.isLatestConditionExist = isLatestConditionExist;
-        this.innerQuerySelectors = innerQuerySelectors;
+        this.useSubSelect = useSubSelect;
+        this.subSelectQuerySelectors = subSelectQuerySelectors;
         this.outerCompiledCondition = outerCompiledCondition;
     }
 
@@ -56,12 +56,12 @@ public class RDBMSCompiledCondition implements CompiledCondition {
         return isContainsConditionExist;
     }
 
-    public boolean isLatestConditionExist() {
-        return isLatestConditionExist;
+    public boolean isUseSubSelect() {
+        return useSubSelect;
     }
 
-    public String getInnerQuerySelectors() {
-        return innerQuerySelectors;
+    public String getSubSelectQuerySelectors() {
+        return subSelectQuerySelectors;
     }
 
     public String getOuterCompiledCondition() {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -33,10 +33,10 @@ import java.util.TreeMap;
 
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.CLOSE_PARENTHESIS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.EQUALS;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SUB_SELECT_QUERY_REF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.OPEN_PARENTHESIS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_MAX;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SUB_SELECT_QUERY_REF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.WHITESPACE;
 
 
@@ -389,8 +389,8 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     public void beginVisitStoreVariable(String storeId, String attributeName, Attribute.Type type) {
         if (!isLastConditionExist) {
             condition.append(this.tableName).append(".").append(attributeName).append(WHITESPACE);
-            outerCompiledCondition.append(this.tableName).append(".").append(attributeName)
-                                            .append(EQUALS).append(SUB_SELECT_QUERY_REF).append(".").append(attributeName);
+            outerCompiledCondition.append(this.tableName).append(".").append(attributeName).append(EQUALS)
+                    .append(SUB_SELECT_QUERY_REF).append(".").append(attributeName);
         } else if (isNextProcessLastPattern) {
             condition.append(this.tableName).append(".").append(attributeName);
             if (isNextProcessLastPattern) {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -33,7 +33,7 @@ import java.util.TreeMap;
 
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.CLOSE_PARENTHESIS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.EQUALS;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.INNER_QUERY_REF;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SUB_SELECT_QUERY_REF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.OPEN_PARENTHESIS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_MAX;
@@ -390,7 +390,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
         if (!isLastConditionExist) {
             condition.append(this.tableName).append(".").append(attributeName).append(WHITESPACE);
             outerCompiledCondition.append(this.tableName).append(".").append(attributeName)
-                                            .append(EQUALS).append(INNER_QUERY_REF).append(".").append(attributeName);
+                                            .append(EQUALS).append(SUB_SELECT_QUERY_REF).append(".").append(attributeName);
         } else if (isNextProcessLastPattern) {
             condition.append(this.tableName).append(".").append(attributeName);
             if (isNextProcessLastPattern) {
@@ -401,7 +401,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
                             .append(this.tableName).append(".").append(attributeName).append(CLOSE_PARENTHESIS)
                             .append(SQL_AS).append("MAX_").append(attributeName);
             outerCompiledCondition.append(this.tableName).append(".").append(attributeName).append(EQUALS)
-                            .append(INNER_QUERY_REF).append(".").append("MAX_").append(attributeName);
+                            .append(SUB_SELECT_QUERY_REF).append(".").append("MAX_").append(attributeName);
         }
     }
 

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -27,7 +27,6 @@ import io.siddhi.query.api.expression.condition.Compare;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -34,9 +34,9 @@ import java.util.TreeMap;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.CLOSE_PARENTHESIS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.EQUALS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.INNER_QUERY_REF;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_MAX;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.OPEN_PARENTHESIS;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_MAX;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.WHITESPACE;
 
 

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -349,7 +349,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
                 (Arrays.stream(supportedFunctions).anyMatch(functionName::equals)) ||
                 (namespace.trim().equals("incrementalAggregator") && functionName.equals("last"))) {
             condition.append(CLOSE_PARENTHESIS).append(WHITESPACE);
-        } else if (!(namespace.trim().equals("incrementalAggregator") && functionName.equals("last"))) {
+        } else {
             throw new OperationNotSupportedException("The RDBMS Event table does not support functions other than " +
                     "sum(), avg(), min(), max(), str:contains() and incrementalAggregator:last() but function '" +
                     ((RDBMSTableUtils.isEmpty(namespace)) ? "" + functionName : namespace + ":" + functionName) +

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.Stack;
 import java.util.TreeMap;
 
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.CLOSE_PARENTHESIS;
@@ -61,9 +62,9 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     private int ordinalOfContainPattern = 1;
 
     private boolean containsAttributeFunction = false;
-    private boolean isLastConditionExist = false;
-    private boolean isNextProcessLastPattern = false;
-    private StringBuilder maxVariableConditionForLast;
+    private boolean lastConditionExist = false;
+    private Stack<String> lastConditionParams;
+    private StringBuilder subSelect;
     private StringBuilder outerCompiledCondition;
 
     private String[] supportedFunctions = {"sum", "avg", "min", "max"};
@@ -75,8 +76,9 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
         this.constantCount = 0;
         this.placeholders = new HashMap<>();
         this.parameters = new TreeMap<>();
-        this.maxVariableConditionForLast = new StringBuilder();
+        this.subSelect = new StringBuilder();
         this.outerCompiledCondition = new StringBuilder();
+        this.lastConditionParams = new Stack<>();
     }
 
     private RDBMSConditionVisitor() {
@@ -89,7 +91,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     }
 
     public String returnMaxVariableCondition() {
-        return this.maxVariableConditionForLast.toString();
+        return this.subSelect.toString();
     }
 
     public boolean isContainsAttributeFunction() {
@@ -101,7 +103,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     }
 
     public boolean isLastConditionExist() {
-        return isLastConditionExist;
+        return lastConditionExist;
     }
 
     public int getOrdinalOfContainPattern() {
@@ -331,9 +333,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
             isContainsConditionExist = true;
             nextProcessContainsPattern = true;
         } else if (namespace.trim().equals("incrementalAggregator") && functionName.equals("last")) {
-            condition.append(SQL_MAX).append(OPEN_PARENTHESIS);
-            isLastConditionExist = true;
-            isNextProcessLastPattern = true;
+            lastConditionExist = true;
         } else {
             throw new OperationNotSupportedException("The RDBMS Event table does not support functions other than " +
                     "sum(), avg(), min(), max(), str:contains() and incrementalAggregator:last() but function '" +
@@ -346,9 +346,20 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
     @Override
     public void endVisitAttributeFunction(String namespace, String functionName) {
         if ((namespace.trim().equals("str") && functionName.equals("contains")) ||
-                (Arrays.stream(supportedFunctions).anyMatch(functionName::equals)) ||
-                (namespace.trim().equals("incrementalAggregator") && functionName.equals("last"))) {
+                (Arrays.stream(supportedFunctions).anyMatch(functionName::equals))) {
             condition.append(CLOSE_PARENTHESIS).append(WHITESPACE);
+        } else if (namespace.trim().equals("incrementalAggregator") && functionName.equals("last")) {
+            String maxVariableName = lastConditionParams.pop();
+            subSelect.append(SQL_MAX).append(OPEN_PARENTHESIS)
+                    .append(this.tableName).append(".").append(maxVariableName).append(CLOSE_PARENTHESIS)
+                    .append(SQL_AS).append("MAX_").append(maxVariableName);
+            outerCompiledCondition.append(this.tableName).append(".").append(maxVariableName).append(EQUALS)
+                    .append(SUB_SELECT_QUERY_REF).append(".").append("MAX_").append(maxVariableName);
+
+            String attributeName = lastConditionParams.pop();
+            condition.append(SQL_MAX).append(OPEN_PARENTHESIS).append(this.tableName).append(".").append(attributeName)
+                    .append(CLOSE_PARENTHESIS).append(WHITESPACE);
+
         } else {
             throw new OperationNotSupportedException("The RDBMS Event table does not support functions other than " +
                     "sum(), avg(), min(), max(), str:contains() and incrementalAggregator:last() but function '" +
@@ -387,21 +398,12 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
 
     @Override
     public void beginVisitStoreVariable(String storeId, String attributeName, Attribute.Type type) {
-        if (!isLastConditionExist) {
+        if (!lastConditionExist) {
             condition.append(this.tableName).append(".").append(attributeName).append(WHITESPACE);
             outerCompiledCondition.append(this.tableName).append(".").append(attributeName).append(EQUALS)
                     .append(SUB_SELECT_QUERY_REF).append(".").append(attributeName);
-        } else if (isNextProcessLastPattern) {
-            condition.append(this.tableName).append(".").append(attributeName);
-            if (isNextProcessLastPattern) {
-                isNextProcessLastPattern = false;
-            }
         } else {
-            maxVariableConditionForLast.append(SQL_MAX).append(OPEN_PARENTHESIS)
-                            .append(this.tableName).append(".").append(attributeName).append(CLOSE_PARENTHESIS)
-                            .append(SQL_AS).append("MAX_").append(attributeName);
-            outerCompiledCondition.append(this.tableName).append(".").append(attributeName).append(EQUALS)
-                            .append(SUB_SELECT_QUERY_REF).append(".").append("MAX_").append(attributeName);
+            lastConditionParams.push(attributeName);
         }
     }
 

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -97,7 +97,6 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.FLOAT_TYP
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.GROUP_BY_CLAUSE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.HAVING_CLAUSE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.INDEX_CREATE_QUERY;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SUB_SELECT_QUERY_REF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.INTEGER_TYPE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.IS_LIMIT_BEFORE_OFFSET;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.LIMIT_CLAUSE;
@@ -127,8 +126,8 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_IN
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_SELECT_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_UPDATE_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_CLAUSE;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QUERY_WITH_SUB_SELECT_TEMPLATE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QUERY_TEMPLATE;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QUERY_WITH_SUB_SELECT_TEMPLATE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SEPARATOR;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AND;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
@@ -136,6 +135,7 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_NOT_N
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_PRIMARY_KEY_DEF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.STRING_SIZE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.STRING_TYPE;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SUB_SELECT_QUERY_REF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.TABLE_CHECK_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.TABLE_CREATE_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.TRANSACTION_SUPPORTED;
@@ -1747,7 +1747,9 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
         Connection conn = this.getConnection();
         PreparedStatement stmt;
         String query = getSelectQuery(rdbmsCompiledCondition, rdbmsCompiledSelection);
-        log.info("Store Query SQL Syntax: '" + query + "'");
+        if (log.isDebugEnabled()) {
+            log.debug("Store Query SQL Syntax: '" + query + "'");
+        }
         try {
             stmt = conn.prepareStatement(query);
         } catch (SQLException e) {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -131,6 +131,7 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QU
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SEPARATOR;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AND;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_MAX;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_NOT_NULL;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_PRIMARY_KEY_DEF;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.STRING_SIZE;
@@ -2055,8 +2056,9 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                         isLastFunctionEncountered = true;
                     }
                 } else if (visitor.isContainsAttributeFunction()) {
-                    compiledSelectionList.append(SUB_SELECT_QUERY_REF).append(".")
-                            .append(selectAttributeBuilder.getRename()).append(SQL_AS)
+                    compiledSelectionList.append(SQL_MAX).append(OPEN_PARENTHESIS)
+                            .append(SUB_SELECT_QUERY_REF).append(".").append(selectAttributeBuilder.getRename())
+                            .append(CLOSE_PARENTHESIS).append(SQL_AS)
                             .append(selectAttributeBuilder.getRename()).append(SEPARATOR);
                     compiledSubSelectQuerySelection.append(compiledCondition).append(SQL_AS)
                                 .append(selectAttributeBuilder.getRename()).append(SEPARATOR);

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -127,8 +127,8 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_IN
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_SELECT_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.RECORD_UPDATE_QUERY;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_CLAUSE;
-import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QUERY_TEMPLATE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_FROM_MULTIPLE_TABLE_TEMPLATE;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SELECT_QUERY_TEMPLATE;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SEPARATOR;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AND;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.SQL_AS;
@@ -1989,7 +1989,16 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 whereClause = whereClause.replace(PLACEHOLDER_CONDITION,
                         rdbmsCompiledSelection.getCompiledSelectClause().getOuterCompiledCondition());
 
-                return selectQueryFromMultipleTables + WHITESPACE + whereClause;
+                 selectQueryFromMultipleTables = selectQueryFromMultipleTables + WHITESPACE + whereClause;
+
+                 String groupByClause = rdbmsSelectQueryTemplate.getGroupByClause();
+                    if (compiledGroupByClause != null) {
+                    groupByClause = groupByClause.replace(PLACEHOLDER_COLUMNS,
+                                                                        compiledGroupByClause.getCompiledQuery());
+                    selectQueryFromMultipleTables = selectQueryFromMultipleTables + WHITESPACE + groupByClause;
+                }
+
+                return selectQueryFromMultipleTables;
             }
 
             return selectQuery.toString();

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -1970,10 +1970,9 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
 
                 String selectQueryWithSubSelect = rdbmsSelectQueryTemplate.getSelectQueryWithSubSelect();
                 if (selectQueryWithSubSelect == null || selectQueryWithSubSelect.isEmpty()) {
-                    throw new QueryableRecordTableException("Select query from two tables for " +
-                            "incrementalAggregator:last() is used in the query but 'selectQueryWithSubSelect' " +
-                            "has not being configured in RDBMS Event Table query configuration, for store: "
-                            + tableName);
+                    throw new QueryableRecordTableException("incrementalAggregator:last() is used in the query but " +
+                            "'selectQueryWithSubSelect' has not being configured in RDBMS Event Table query " +
+                            "configuration, for store: " + tableName);
                 }
                 String whereClause = rdbmsSelectQueryTemplate.getWhereClause();
                 if (whereClause == null || whereClause.isEmpty()) {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -2058,14 +2058,19 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
 
             if (containsLastFunction) {
                 if (visitor.isLastConditionExist()) {
+                    // Add the select columns with function incrementalAggregator:last()
                     compiledSelectionList.append(compiledCondition).append(SQL_AS)
                             .append(selectAttributeBuilder.getRename()).append(SEPARATOR);
                     if (!isLastFunctionEncountered) {
+                        //Only add max variable for incrementalAggregator:last() once
                         compiledSubSelectQuerySelection.append(visitor.returnMaxVariableCondition()).append(SEPARATOR);
                         compiledOuterOnCondition.append(visitor.getOuterCompiledCondition()).append(SQL_AND);
                         isLastFunctionEncountered = true;
                     }
                 } else if (visitor.isContainsAttributeFunction()) {
+                    //Add columns with attributes function such as sum(), max()
+                    //Add max(variable) by default since oracle all columns not in group by must have
+                    // attribute function
                     compiledSelectionList.append(SQL_MAX).append(OPEN_PARENTHESIS)
                             .append(SUB_SELECT_QUERY_REF).append(".").append(selectAttributeBuilder.getRename())
                             .append(CLOSE_PARENTHESIS).append(SQL_AS)
@@ -2073,6 +2078,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                     compiledSubSelectQuerySelection.append(compiledCondition).append(SQL_AS)
                                 .append(selectAttributeBuilder.getRename()).append(SEPARATOR);
                 } else {
+                    // Add group by column
                     compiledSelectionList.append(compiledCondition).append(SQL_AS)
                             .append(selectAttributeBuilder.getRename()).append(SEPARATOR);
                     compiledSubSelectQuerySelection.append(compiledCondition).append(SQL_AS)

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSSelectQueryTemplate.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSSelectQueryTemplate.java
@@ -24,6 +24,7 @@ package io.siddhi.extension.store.rdbms.config;
 public class RDBMSSelectQueryTemplate {
 
     private String selectClause;
+    private String selectQueryFromMultipleTables;
     private String whereClause;
     private String groupByClause;
     private String havingClause;
@@ -121,5 +122,13 @@ public class RDBMSSelectQueryTemplate {
 
     public void setOffsetWrapperClause(String offsetWrapperClause) {
         this.offsetWrapperClause = offsetWrapperClause;
+    }
+
+    public String getSelectQueryFromMultipleTables() {
+        return selectQueryFromMultipleTables;
+    }
+
+    public void setSelectQueryFromMultipleTables(String selectQueryFromMultipleTables) {
+        this.selectQueryFromMultipleTables = selectQueryFromMultipleTables;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSSelectQueryTemplate.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSSelectQueryTemplate.java
@@ -24,7 +24,7 @@ package io.siddhi.extension.store.rdbms.config;
 public class RDBMSSelectQueryTemplate {
 
     private String selectClause;
-    private String selectQueryFromMultipleTables;
+    private String selectQueryWithSubSelect;
     private String whereClause;
     private String groupByClause;
     private String havingClause;
@@ -124,11 +124,11 @@ public class RDBMSSelectQueryTemplate {
         this.offsetWrapperClause = offsetWrapperClause;
     }
 
-    public String getSelectQueryFromMultipleTables() {
-        return selectQueryFromMultipleTables;
+    public String getSelectQueryWithSubSelect() {
+        return selectQueryWithSubSelect;
     }
 
-    public void setSelectQueryFromMultipleTables(String selectQueryFromMultipleTables) {
-        this.selectQueryFromMultipleTables = selectQueryFromMultipleTables;
+    public void setSelectQueryWithSubSelect(String selectQueryWithSubSelect) {
+        this.selectQueryWithSubSelect = selectQueryWithSubSelect;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -62,6 +62,7 @@ public class RDBMSTableConstants {
     public static final String SQL_PRIMARY_KEY_DEF = "PRIMARY KEY";
     public static final String SQL_WHERE = "WHERE";
     public static final String SQL_AS = " AS ";
+    public static final String SQL_MAX = "MAX"; // Used for incrementalAggregator:last()
     public static final String WHITESPACE = " ";
     public static final String SEPARATOR = ", ";
     public static final String EQUALS = "=";
@@ -69,7 +70,6 @@ public class RDBMSTableConstants {
     public static final String OPEN_PARENTHESIS = "(";
     public static final String CLOSE_PARENTHESIS = ")";
     public static final String INNER_QUERY_REF = "t2";
-    public static final String LAST_MAX_FUNCTION = "max"; // Used for incrementalAggregator:last()
 
     public static final String CONTAINS_CONDITION_REGEX = "(CONTAINS\\()([a-zA-z.]*)(\\s\\?\\s\\))";
 

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -69,7 +69,7 @@ public class RDBMSTableConstants {
     public static final String QUESTION_MARK = "?";
     public static final String OPEN_PARENTHESIS = "(";
     public static final String CLOSE_PARENTHESIS = ")";
-    public static final String INNER_QUERY_REF = "t2";
+    public static final String SUB_SELECT_QUERY_REF = "t2";
 
     public static final String CONTAINS_CONDITION_REGEX = "(CONTAINS\\()([a-zA-z.]*)(\\s\\?\\s\\))";
 
@@ -112,7 +112,7 @@ public class RDBMSTableConstants {
     public static final String BATCH_ENABLE = "batchEnable";
     public static final String TRANSACTION_SUPPORTED = "transactionSupported";
     public static final String SELECT_QUERY_TEMPLATE = "selectQueryTemplate";
-    public static final String SELECT_FROM_MULTIPLE_TABLE_TEMPLATE = "selectQueryFromMultipleTables";
+    public static final String SELECT_QUERY_WITH_SUB_SELECT_TEMPLATE = "selectQueryWithSubSelect";
     public static final String SELECT_CLAUSE = "selectClause";
     public static final String WHERE_CLAUSE = "whereClause";
     public static final String GROUP_BY_CLAUSE = "groupByClause";

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -53,7 +53,7 @@ public class RDBMSTableConstants {
     public static final String SQL_COMPARE_GREATER_THAN_EQUAL = ">=";
     public static final String SQL_COMPARE_EQUAL = "=";
     public static final String SQL_COMPARE_NOT_EQUAL = "<>"; //Using the ANSI SQL-92 standard over '!=' (non-standard)
-    public static final String SQL_AND = "AND";
+    public static final String SQL_AND = " AND ";
     public static final String SQL_OR = "OR";
     public static final String SQL_NOT = "NOT";
     public static final String SQL_IN = "IN";
@@ -68,6 +68,8 @@ public class RDBMSTableConstants {
     public static final String QUESTION_MARK = "?";
     public static final String OPEN_PARENTHESIS = "(";
     public static final String CLOSE_PARENTHESIS = ")";
+    public static final String INNER_QUERY_REF = "t2";
+    public static final String LAST_MAX_FUNCTION = "max"; // Used for incrementalAggregator:last()
 
     public static final String CONTAINS_CONDITION_REGEX = "(CONTAINS\\()([a-zA-z.]*)(\\s\\?\\s\\))";
 

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -112,6 +112,7 @@ public class RDBMSTableConstants {
     public static final String BATCH_ENABLE = "batchEnable";
     public static final String TRANSACTION_SUPPORTED = "transactionSupported";
     public static final String SELECT_QUERY_TEMPLATE = "selectQueryTemplate";
+    public static final String SELECT_FROM_MULTIPLE_TABLE_TEMPLATE = "selectQueryFromMultipleTables";
     public static final String SELECT_CLAUSE = "selectClause";
     public static final String WHERE_CLAUSE = "whereClause";
     public static final String GROUP_BY_CLAUSE = "groupByClause";

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -156,7 +156,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectClauseWithInnerQuery>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectClauseWithInnerQuery>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -13,6 +13,7 @@
         <recordContainsCondition>{{COLUMNS}} LIKE {{VALUES}}</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -46,6 +47,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -79,6 +81,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -117,6 +120,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -152,6 +156,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectClauseWithInnerQuery>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectClauseWithInnerQuery>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -185,6 +190,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -218,6 +224,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -252,6 +259,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -13,7 +13,7 @@
         <recordContainsCondition>{{COLUMNS}} LIKE {{VALUES}}</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -47,7 +47,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -81,7 +81,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -120,7 +120,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -190,7 +190,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -224,7 +224,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -259,7 +259,7 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryFromMultipleTables>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryFromMultipleTables>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/DeleteFromRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/DeleteFromRDBMSTableTestCaseIT.java
@@ -66,7 +66,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 "define table StockTable (symbol string, price float, volume long); ";
         String query = "" +
                 "@info(name = 'query1') " +
@@ -105,7 +106,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -145,7 +147,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -183,7 +186,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -222,7 +226,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -260,7 +265,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -299,7 +305,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -337,7 +344,8 @@ public class DeleteFromRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "define stream DeleteStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
-                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                "pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
@@ -77,7 +77,7 @@ public class InsertIntoRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName
-                + "\", field.length=\"symbol:100\")\n" +
+                + "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, volume long); ";
@@ -109,7 +109,7 @@ public class InsertIntoRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol, price\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -145,7 +145,7 @@ public class InsertIntoRDBMSTableTestCaseIT {
         String table = "" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol, price\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long);\n" +
@@ -191,7 +191,7 @@ public class InsertIntoRDBMSTableTestCaseIT {
         String table = "" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", table.name=\"StockTable\"," +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100, message:5000\")\n" +
+                "\", field.length=\"symbol:100, message:5000\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 "define table " + TABLE_NAME + " (symbol string, message string);\n";
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/JoinRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/JoinRDBMSTableTestCaseIT.java
@@ -77,7 +77,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -145,7 +145,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -212,7 +212,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol1 string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -278,7 +278,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -343,7 +343,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -408,7 +408,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -473,7 +473,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -540,7 +540,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float); ";
@@ -605,7 +605,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +
@@ -674,7 +674,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +
@@ -746,7 +746,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +
@@ -815,7 +815,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +
@@ -888,7 +888,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, price float); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +
@@ -960,7 +960,7 @@ public class JoinRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, price float); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "@connection(maxWait = '4000')" +

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/ReadEventRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/ReadEventRDBMSTableTestCaseIT.java
@@ -79,7 +79,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "define stream OutputStream (checkName string, checkCategory string, checkVolume long);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"itemId:100\")\n" +
+                "\", field.length=\"itemId:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"itemId\")\n" +
                 "define table StockTable (itemId string, type string, volume long);\n";
 
@@ -173,7 +173,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "define stream OutputStream (checkName string, checkCategory string, checkVolume long);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"itemId:100\")\n" +
+                "\", field.length=\"itemId:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"itemId\")\n" +
                 "define table StockTable (itemId string, type string, volume long);\n";
 
@@ -212,7 +212,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "define stream OutputStream (checkName string, checkCategory string, checkVolume long);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"itemId:100\")\n" +
+                "\", field.length=\"itemId:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"itemId\")\n" +
                 "define table StockTable (itemId string, type string, volume long);\n";
 
@@ -298,7 +298,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "define stream OutputStream (checkName string, checkCategory string, checkVolume long);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"itemId:100\")\n" +
+                "\", field.length=\"itemId:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"itemId\")\n" +
                 "define table StockTable (itemId string, type string, volume long);\n";
 
@@ -378,7 +378,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "define stream OutputStream (checkName string, checkCategory string, checkVolume double);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"name:100\")\n" +
+                "\", field.length=\"name:100\", pool.properties=\"maximumPoolSize:1\")\n" +
 //                "@PrimaryKey(\"itemId\")\n" +
                 "define table StockTable (name string, type string, volume long);\n";
 
@@ -445,7 +445,7 @@ public class ReadEventRDBMSTableTestCaseIT {
                 "column5 bool, column6 double);\n" +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"column1:100\")\n" +
+                "\", field.length=\"column1:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "define table StockTable (column1 string, column2 string, column3 string, column4 float, " +
                 "column5 bool, column6 double);\n";
         String streams2 = "" +

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/UpdateOrInsertRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/UpdateOrInsertRDBMSTableTestCaseIT.java
@@ -84,7 +84,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -120,7 +120,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -157,7 +157,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -236,7 +236,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -311,7 +311,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, vol long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -395,7 +395,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, vol long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -478,7 +478,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, vol long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -555,7 +555,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long, price float); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -628,7 +628,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, vol long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -708,7 +708,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, vol long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -786,7 +786,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -825,7 +825,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -864,7 +864,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";
@@ -926,7 +926,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\", \"volume\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";
@@ -988,7 +988,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";
@@ -1051,7 +1051,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (apiName string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"apiName:100\")\n" +
+                "\", field.length=\"apiName:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\'apiName\',\'apiCreatorTenantDomain\',\'apiCreator\')\n" +
                 "define table ApiLastAccessSummary (apiName string, apiCreatorTenantDomain string, " +
                 "apiContext string, apiVersion string, applicationOwner string, lastAccessTime long," +
@@ -1133,7 +1133,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";
@@ -1219,7 +1219,7 @@ public class UpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream SearchStream (symbol string); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/UpdateRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/UpdateRDBMSTableTestCaseIT.java
@@ -76,7 +76,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price double, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price double, volume long); ";
@@ -117,7 +117,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price double, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price double, volume long); ";
@@ -156,7 +156,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -210,7 +210,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\",field.length=\"symbol:100\")\n" +
+                "\",field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -265,7 +265,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\",field.length=\"symbol:100\")\n" +
+                "\",field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -319,7 +319,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream CheckStockStream (symbol string, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\",field.length=\"symbol:100\")\n" +
+                "\",field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -375,7 +375,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (comp string, prc float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\",field.length=\"symbol:100\")\n" +
+                "\",field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -454,7 +454,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -493,7 +493,7 @@ public class UpdateRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price double, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price double, volume long); ";

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/AggregationFilterTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/AggregationFilterTestCaseIT.java
@@ -58,7 +58,6 @@ public class AggregationFilterTestCaseIT {
         try {
             RDBMSTableTestUtils.initDatabaseTable("stockAggregation_SECONDS");
             RDBMSTableTestUtils.initDatabaseTable("stockAggregation_MINUTES");
-            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_HOURS");
         } catch (SQLException e) {
             LOG.error("Test case ignored due to " + e.getMessage());
         }
@@ -83,7 +82,7 @@ public class AggregationFilterTestCaseIT {
                 "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, (price * quantity) " +
                 "as lastTradeValue  " +
                 "group by symbol " +
-                "aggregate by timestamp every sec...hour; " +
+                "aggregate by timestamp every sec...min; " +
 
                 "define stream inputStream (symbol string, value int, startTime string, " +
                 "endTime string, perValue string); " +
@@ -190,7 +189,7 @@ public class AggregationFilterTestCaseIT {
                 "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, (price * quantity) " +
                 "as lastTradeValue  " +
                 "group by symbol " +
-                "aggregate by timestamp every sec...hour; " +
+                "aggregate by timestamp every sec...min; " +
 
                 "define stream inputStream (symbol string, value int, startTime string, " +
                 "endTime string, perValue string); " +
@@ -297,7 +296,7 @@ public class AggregationFilterTestCaseIT {
                 "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, " +
                 "(price * quantity) as lastTradeValue " +
                 "group by symbol " +
-                "aggregate by timestamp every sec...hour; " +
+                "aggregate by timestamp every sec...min; " +
 
                 "define stream inputStream (symbol string, value int, startTime string, " +
                 "endTime string, perValue string); " +
@@ -423,7 +422,7 @@ public class AggregationFilterTestCaseIT {
                 "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, (price * quantity) " +
                 "as lastTradeValue  " +
                 "group by symbol " +
-                "aggregate by timestamp every sec...hour ;";
+                "aggregate by timestamp every sec...min ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
 
@@ -471,7 +470,7 @@ public class AggregationFilterTestCaseIT {
                         "select symbol, avg(price) as avgPrice, sum(price) as totalPrice, " +
                         "(price * quantity) as lastTradeValue  " +
                         "group by symbol " +
-                        "aggregate every sec...hour ;";
+                        "aggregate every sec...min ;";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/DistributedAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/DistributedAggregationTestCaseIT.java
@@ -1106,7 +1106,7 @@ public class DistributedAggregationTestCaseIT {
                 "define aggregation stockAggregation\n" +
                 "from stockStream \n" +
                 "select symbol,sum(price) as totalPrice,avg(price) as avgPrice \n" +
-                "aggregate by timestamp every sec...year; ";
+                "aggregate by timestamp every sec...hour; ";
 
         SiddhiAppRuntime siddhiAppRuntime1 = siddhiManager1.createSiddhiAppRuntime(streams + query);
         SiddhiAppRuntime siddhiAppRuntime2 = siddhiManager2.createSiddhiAppRuntime(streams + query);
@@ -1374,8 +1374,6 @@ public class DistributedAggregationTestCaseIT {
             RDBMSTableTestUtils.initDatabaseTable("stockNormalAggregation_MINUTES");
             RDBMSTableTestUtils.initDatabaseTable("stockNormalAggregation_HOURS");
             RDBMSTableTestUtils.initDatabaseTable("stockNormalAggregation_DAYS");
-            RDBMSTableTestUtils.initDatabaseTable("stockNormalAggregation_MONTHS");
-            RDBMSTableTestUtils.initDatabaseTable("stockNormalAggregation_YEARS");
         } catch (SQLException e) {
             log.info("Test case ignored due to " + e.getMessage());
         }
@@ -1412,7 +1410,7 @@ public class DistributedAggregationTestCaseIT {
                 "define aggregation stockAggregation\n" +
                 "from stockStream \n" +
                 "select symbol,sum(price) as totalPrice,avg(price) as avgPrice \n" +
-                "aggregate by timestamp every sec...year; ";
+                "aggregate by timestamp every sec...day; ";
 
         String query2 = "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
@@ -1421,7 +1419,7 @@ public class DistributedAggregationTestCaseIT {
                 "define aggregation stockNormalAggregation\n" +
                 "from stockStream \n" +
                 "select symbol,sum(price) as totalPrice,avg(price) as avgPrice \n" +
-                "aggregate by timestamp every sec...year; ";
+                "aggregate by timestamp every sec...day; ";
 
         SiddhiAppRuntime siddhiAppRuntime1 = siddhiManager1.createSiddhiAppRuntime(streams + query + query2);
         SiddhiAppRuntime siddhiAppRuntime2 = siddhiManager2.createSiddhiAppRuntime(streams + query);

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/InitialiseExecutorsAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/InitialiseExecutorsAggregationTestCaseIT.java
@@ -41,8 +41,8 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.password;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.url;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.user;
 
-public class IncrementalAggregationTestCaseIT {
-    private static final Logger log = Logger.getLogger(IncrementalAggregationTestCaseIT.class);
+public class InitialiseExecutorsAggregationTestCaseIT {
+    private static final Logger log = Logger.getLogger(InitialiseExecutorsAggregationTestCaseIT.class);
 
     @BeforeClass
     public static void startTest() {

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/LatestAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/LatestAggregationTestCaseIT.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.store.rdbms.aggregation;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.password;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.url;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.user;
+
+public class LatestAggregationTestCaseIT {
+
+    private static final Logger LOG = Logger.getLogger(LatestAggregationTestCaseIT.class);
+    private AtomicInteger inEventCount;
+    private AtomicInteger removeEventCount;
+    private boolean eventArrived;
+    private List<Object[]> inEventsList;
+    private List<Object[]> removeEventsList;
+
+    @BeforeMethod
+    public void init() {
+        inEventCount = new AtomicInteger(0);
+        removeEventCount = new AtomicInteger(0);
+        eventArrived = false;
+        inEventsList = new ArrayList<>();
+        removeEventsList = new ArrayList<>();
+
+        try {
+            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_SECONDS");
+            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_MINUTES");
+            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_HOURS");
+        } catch (SQLException e) {
+            LOG.error("Test case ignored due to " + e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void latestTestCase1() throws InterruptedException {
+        LOG.info("latestTestCase: testing latest incremental aggregator");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
+                "aggregate by timestamp every sec...hour ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select AGG_TIMESTAMP, s.symbol, s.latestPrice " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                    if (removeEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : removeEvents) {
+                            removeEventsList.add(event.getData());
+                            removeEventCount.incrementAndGet();
+                        }
+                    }
+                    eventArrived = true;
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, "WSO22", 750f},
+                    new Object[]{1496289952000L, "WSO24", 1600f},
+                    new Object[]{1496289954000L, "IBM1", 10200f},
+                    new Object[]{1496289956000L, "IBM1", 3500f}
+            );
+            SiddhiTestHelper.waitForEvents(100, 4, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                                                SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+            AssertJUnit.assertEquals("Number of remove events", 4, removeEventCount.get());
+            AssertJUnit.assertTrue("Remove events matched",
+                                                SiddhiTestHelper.isUnsortedEventsMatch(removeEventsList, expected));
+
+             } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "latestTestCase1")
+    public void latestTestCase2() throws InterruptedException {
+        LOG.info("latestTestCase2: testing latest incremental aggregator - different group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
+                "aggregate by timestamp every sec...hour ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select s.symbol, s.latestPrice " +
+                "group by s.symbol " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                    if (removeEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : removeEvents) {
+                            removeEventsList.add(event.getData());
+                            removeEventCount.incrementAndGet();
+                        }
+                    }
+                    eventArrived = true;
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO22", 750f},
+                    new Object[]{"WSO24", 1600f},
+                    new Object[]{"IBM1", 3500f}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+            AssertJUnit.assertEquals("Number of remove events", 3, removeEventCount.get());
+            AssertJUnit.assertTrue("Remove events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(removeEventsList, expected));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "latestTestCase2")
+    public void latestTestCase3() throws InterruptedException {
+        LOG.info("latestTestCase3: testing latest incremental aggregator with another agg");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
+                "aggregate by timestamp every sec...hour ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select AGG_TIMESTAMP, s.symbol, s.latestPrice, s.avgPrice " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                    if (removeEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : removeEvents) {
+                            removeEventsList.add(event.getData());
+                            removeEventCount.incrementAndGet();
+                        }
+                    }
+                    eventArrived = true;
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, "WSO22", 750f, 65.0},
+                    new Object[]{1496289952000L, "WSO24", 1600f, 80.0},
+                    new Object[]{1496289954000L, "IBM1", 10200f, 101.5},
+                    new Object[]{1496289956000L, "IBM1", 3500f, 700.0}
+            );
+            SiddhiTestHelper.waitForEvents(100, 4, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 4, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+            AssertJUnit.assertEquals("Number of remove events", 4, removeEventCount.get());
+            AssertJUnit.assertTrue("Remove events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(removeEventsList, expected));
+
+        } finally {
+
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "latestTestCase3")
+    public void latestTestCase4() throws InterruptedException {
+        LOG.info("latestTestCase4: testing latest incremental aggregator - different group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
+                "aggregate by timestamp every sec...hour ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select s.symbol, s.latestPrice, sum(s.avgPrice) as totalAvg " +
+                "group by s.symbol " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO22", 750f, 65.0},
+                    new Object[]{"WSO24", 1600f, 80.0},
+                    new Object[]{"IBM1", 3500f, 801.5}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+}

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/LatestAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/LatestAggregationTestCaseIT.java
@@ -62,7 +62,6 @@ public class LatestAggregationTestCaseIT {
         try {
             RDBMSTableTestUtils.initDatabaseTable("stockAggregation_SECONDS");
             RDBMSTableTestUtils.initDatabaseTable("stockAggregation_MINUTES");
-            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_HOURS");
         } catch (SQLException e) {
             LOG.error("Test case ignored due to " + e.getMessage());
         }
@@ -85,7 +84,7 @@ public class LatestAggregationTestCaseIT {
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
-                "aggregate by timestamp every sec...hour ;" +
+                "aggregate by timestamp every sec...min ;" +
 
                 "define stream inputStream (symbol string); " +
 
@@ -187,7 +186,7 @@ public class LatestAggregationTestCaseIT {
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
-                "aggregate by timestamp every sec...hour ;" +
+                "aggregate by timestamp every sec...min ;" +
 
                 "define stream inputStream (symbol string); " +
 
@@ -289,7 +288,7 @@ public class LatestAggregationTestCaseIT {
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
-                "aggregate by timestamp every sec...hour ;" +
+                "aggregate by timestamp every sec...min ;" +
 
                 "define stream inputStream (symbol string); " +
 
@@ -392,7 +391,7 @@ public class LatestAggregationTestCaseIT {
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select symbol, avg(price) as avgPrice, (price * quantity) as latestPrice " +
-                "aggregate by timestamp every sec...hour ;" +
+                "aggregate by timestamp every sec...min ;" +
 
                 "define stream inputStream (symbol string); " +
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
@@ -730,8 +730,7 @@ public class SelectOptimisationAggregationTestCaseIT {
 
             List<Object[]> expected = Arrays.asList(
                     new Object[]{"WSO2", "WSO22", 4L},
-                    // TODO: 12/06/19 Original assert was  new Object[]{"IBM", "IBM1", 6L},
-                    new Object[]{"IBM", "IBM2", 6L},
+                    new Object[]{"IBM", "IBM1", 6L},
                     new Object[]{"CISCO", "CISCO1", 1L}
             );
             SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 60000);

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
@@ -730,7 +730,7 @@ public class SelectOptimisationAggregationTestCaseIT {
 
             List<Object[]> expected = Arrays.asList(
                     new Object[]{"WSO2", "WSO22", 4L},
-                    // TODO: 12/06/19
+                    // TODO: 12/06/19 Original assert was  new Object[]{"IBM", "IBM1", 6L},
                     new Object[]{"IBM", "IBM2", 6L},
                     new Object[]{"CISCO", "CISCO1", 1L}
             );

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
@@ -1,0 +1,1266 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.store.rdbms.aggregation;
+
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.query.output.callback.QueryCallback;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
+import org.apache.log4j.Logger;
+import org.testng.AssertJUnit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.password;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.url;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.user;
+
+public class SelectOptimisationAggregationTestCaseIT {
+
+    private static final Logger LOG = Logger.getLogger(SelectOptimisationAggregationTestCaseIT.class);
+    private boolean eventArrived;
+    private AtomicInteger inEventCount;
+    private List<Object[]> inEventsList;
+
+    @BeforeMethod
+    public void init() {
+        inEventCount = new AtomicInteger(0);
+        eventArrived = false;
+        inEventsList = new ArrayList<>();
+
+        try {
+            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_SECONDS");
+            RDBMSTableTestUtils.initDatabaseTable("stockAggregation_MINUTES");
+        } catch (SQLException e) {
+            LOG.error("Test case ignored due to " + e.getMessage());
+        }
+
+    }
+
+    @Test
+    public void aggregationFunctionTestcase1() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase1 - count w/o group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select count() as count " +
+                "aggregate every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select count " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+            Thread.sleep(1000);
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            // AGG_TIMESTAMP cannot be asserted as it is based on the time test case is run
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{2L},
+                    new Object[]{2L},
+                    new Object[]{2L},
+                    new Object[]{2L},
+                    new Object[]{1L},
+                    new Object[]{1L},
+                    new Object[]{1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 7, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 7, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched", SiddhiTestHelper.isEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test( dependsOnMethods = "aggregationFunctionTestcase1")
+    public void aggregationFunctionTestcase2() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase1 - external timestamp count w/o group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select count() as count " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select AGG_TIMESTAMP, count " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, 2L},
+                    new Object[]{1496289952000L, 2L},
+                    new Object[]{1496289954000L, 2L},
+                    new Object[]{1496289956000L, 2L},
+                    new Object[]{1496290016000L, 1L},
+                    new Object[]{1496290076000L, 1L},
+                    new Object[]{1496293676000L, 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 7, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 7, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched", SiddhiTestHelper.isEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase2")
+    public void aggregationFunctionTestcase3() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase2 - count w/o group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, count() as count " +
+                "group by symbol " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select AGG_TIMESTAMP, s.symbol, s.count " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, "WSO2", 2L},
+                    new Object[]{1496289952000L, "WSO2", 2L},
+                    new Object[]{1496289954000L, "IBM", 2L},
+                    new Object[]{1496289956000L, "IBM", 2L},
+                    new Object[]{1496290016000L, "IBM", 1L},
+                    new Object[]{1496290076000L, "IBM", 1L},
+                    new Object[]{1496293676000L, "CISCO", 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 7, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 7, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase3")
+    public void aggregationFunctionTestcase4() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase2 - count with same group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, count() as count " +
+                "group by symbol " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select s.symbol, sum(count) as count " +
+                "group by s.symbol " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO2", 4L},
+                    new Object[]{"IBM", 6L},
+                    new Object[]{"CISCO", 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase4")
+    public void aggregationFunctionTestcase5() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase2 - count with different group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, name string, price float, lastClosingPrice float, " +
+                        "volume long , quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, name, count() as count " +
+                "group by symbol, name " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select s.symbol, s.name, sum(count) as count " +
+                "group by s.symbol " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", "CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO2", "WSO2", 4L},
+                    new Object[]{"IBM", "IBM", 6L},
+                    new Object[]{"CISCO", "CISCO", 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase5")
+    public void aggregationFunctionTestcase6() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase2 - count with different group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, name string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, name, count() as count " +
+                "group by symbol, name " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select s.symbol, sum(count) as count " +
+                "group by s.symbol " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO21", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO21", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22",100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM2", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM2", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", "CISCO1", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO2", 4L},
+                    new Object[]{"IBM", 6L},
+                    new Object[]{"CISCO", 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase6")
+    public void aggregationFunctionTestcase7() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase7 - count with different group by");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, name string, price float, lastClosingPrice float, " +
+                        "volume long , quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, name, count() as count " +
+                "group by symbol, name " +
+                "aggregate by timestamp every sec, min ;" +
+
+                "define stream inputStream (symbol string, value int, startTime string, " +
+                "endTime string, perValue string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596434876000L " +
+                "per \"seconds\" " +
+                "select s.symbol, s.name, sum(count) as count " +
+                "group by s.symbol " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO21", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO21", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM2", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM2", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", "CISCO1", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            inputStreamInputHandler.send(new Object[]{"IBM", 1, "2017-06-01 09:35:51 +05:30",
+                    "2017-06-01 09:35:52 +05:30", "seconds"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO2", "WSO22", 4L},
+                    // TODO: 12/06/19
+                    new Object[]{"IBM", "IBM2", 6L},
+                    new Object[]{"CISCO", "CISCO1", 1L}
+            );
+            SiddhiTestHelper.waitForEvents(100, 3, inEventCount, 60000);
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 3, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase7")
+    public void aggregationFunctionTestcase8() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase3 - count w/o group by store query");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select count() as count " +
+                "aggregate by timestamp every sec, min ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+            Event[] events = siddhiAppRuntime.query("" +
+                    "from stockAggregation " +
+                    "within 1496200000000L, 1596434876000L " +
+                    "per \"seconds\" " +
+                    "select AGG_TIMESTAMP, count " +
+                    "order by AGG_TIMESTAMP;");
+
+            AssertJUnit.assertNotNull("Event arrived", events);
+            AssertJUnit.assertEquals("Number of success events", 7, events.length);
+
+
+            List<Object[]> actual = new ArrayList<>();
+            for (Event event : events) {
+                actual.add(event.getData());
+            }
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{1496289950000L, 2L},
+                    new Object[]{1496289952000L, 2L},
+                    new Object[]{1496289954000L, 2L},
+                    new Object[]{1496289956000L, 2L},
+                    new Object[]{1496290016000L, 1L},
+                    new Object[]{1496290076000L, 1L},
+                    new Object[]{1496293676000L, 1L}
+            );
+            AssertJUnit.assertTrue("In events matched", SiddhiTestHelper.isEventsMatch(actual, expected));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase8")
+    public void aggregationFunctionTestcase9() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase4 - count with group by store query");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, count() as count " +
+                "group by symbol " +
+                "aggregate by timestamp every sec, min ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 70f, null, 40L, 10, 1496289950000L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 100f, null, 200L, 96, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM", 500f, null, 200L, 7, 1496289956000L});
+
+            // Thursday, June 1, 2017 4:06:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 400f, null, 200L, 9, 1496290016000L});
+
+            // Thursday, June 1, 2017 4:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 600f, null, 200L, 6, 1496290076000L});
+
+            // Thursday, June 1, 2017 5:07:56 AM
+            stockStreamInputHandler.send(new Object[]{"CISCO", 700f, null, 200L, 20, 1496293676000L});
+            Thread.sleep(2000);
+
+
+            Event[] events = siddhiAppRuntime.query(
+                    "from stockAggregation " +
+                            "within 1496200000000L, 1596434876000L " +
+                            "per \"seconds\" " +
+                            "select symbol, sum(count) as count " +
+                            "group by symbol;");
+
+            AssertJUnit.assertNotNull("Event arrived", events);
+            AssertJUnit.assertEquals("Number of success events", 3, events.length);
+
+
+            List<Object[]> actual = new ArrayList<>();
+            for (Event event : events) {
+                actual.add(event.getData());
+            }
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO2", 4L},
+                    new Object[]{"IBM", 6L},
+                    new Object[]{"CISCO", 1L}
+            );
+            AssertJUnit.assertTrue("In events matched", SiddhiTestHelper.isUnsortedEventsMatch(actual, expected));
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase9")
+    public void aggregationFunctionTestcase10() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase9: testing latest incremental aggregator - different select ");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, sum(price) as sumPrice " +
+                "group by symbol " +
+                "aggregate by timestamp every sec...min ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select i.symbol, sum(s.sumPrice) as sumPrice " +
+                "group by s.symbol " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"IBM", 75.0},
+                    new Object[]{"IBM", 50.0},
+                    new Object[]{"IBM", 130.0},
+                    new Object[]{"IBM", 100.0},
+                    new Object[]{"IBM", 602.0},
+                    new Object[]{"IBM", 1001.0}
+            );
+            SiddhiTestHelper.waitForEvents(100, 6, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 6, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase10")
+    public void aggregationFunctionTestcase11() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase10: testing latest incremental aggregator - different select ");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, sum(price) as sumPrice  " +
+                "group by symbol " +
+                "aggregate by timestamp every sec...min ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select s.symbol, sum(s.sumPrice) as sumPrice " +
+                "group by i.symbol " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            SiddhiTestHelper.waitForEvents(100, 1, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 1, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    Arrays.equals(inEventsList.get(0), new Object[]{"WSO22", 1958.0}));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase11")
+    public void aggregationFunctionTestcase12() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase11: testing latest incremental aggregator - different select ");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, sum(price) as sumPrice " +
+                "group by symbol " +
+                "aggregate by timestamp every sec...min ;" +
+
+                "define stream inputStream (symbol string); " +
+
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select i.symbol, sum(sumPrice) as totalPrice " +
+                "group by i.symbol " +
+                "order by AGG_TIMESTAMP " +
+                "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            SiddhiTestHelper.waitForEvents(100, 1, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 1, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    Arrays.equals(inEventsList.get(0), new Object[]{"IBM", 1958.0}));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+    @Test(dependsOnMethods = "aggregationFunctionTestcase12")
+    public void aggregationFunctionTestcase13() throws InterruptedException {
+        LOG.info("aggregationFunctionTestcase13: testing latest incremental aggregator - different select ");
+        SiddhiManager siddhiManager = new SiddhiManager();
+
+        String stockStream =
+                "define stream stockStream (symbol string, price float, lastClosingPrice float, volume long , " +
+                        "quantity int, timestamp long);";
+        String query =
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                        "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                        "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                        "@purge(enable='false')" +
+                        "define aggregation stockAggregation " +
+                        "from stockStream " +
+                        "select symbol, sum(price) as sumPrice " +
+                        "group by symbol " +
+                        "aggregate by timestamp every sec...min ;" +
+
+                        "define stream inputStream (symbol string); " +
+
+                        "@info(name = 'query1') " +
+                        "from inputStream as i join stockAggregation as s " +
+                        "within 1496200000000L, 1596535449000L " +
+                        "per \"seconds\" " +
+                        "select s.symbol, sum(s.sumPrice) as sumPrice " +
+                        "group by i.symbol, s.symbol " +
+                        "insert all events into outputStream; ";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
+
+        try {
+            siddhiAppRuntime.addCallback("query1", new QueryCallback() {
+                @Override
+                public void receive(long timestamp, Event[] inEvents, Event[] removeEvents) {
+                    if (inEvents != null) {
+                        EventPrinter.print(timestamp, inEvents, removeEvents);
+                        for (Event event : inEvents) {
+                            inEventsList.add(event.getData());
+                            inEventCount.incrementAndGet();
+                        }
+                        eventArrived = true;
+                    }
+                }
+            });
+            InputHandler stockStreamInputHandler = siddhiAppRuntime.getInputHandler("stockStream");
+            InputHandler inputStreamInputHandler = siddhiAppRuntime.getInputHandler("inputStream");
+            siddhiAppRuntime.start();
+
+            // Thursday, June 1, 2017 4:05:50 AM
+            stockStreamInputHandler.send(new Object[]{"WSO2", 50f, 60f, 90L, 6, 1496289950000L});
+            stockStreamInputHandler.send(new Object[]{"WSO22", 75f, null, 40L, 10, 1496289950100L});
+
+            // Thursday, June 1, 2017 4:05:52 AM
+            stockStreamInputHandler.send(new Object[]{"WSO23", 60f, 44f, 200L, 56, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO24", 100f, null, 200L, 16, 1496289952000L});
+
+            // Thursday, June 1, 2017 4:05:50 AM - Out of order event
+            stockStreamInputHandler.send(new Object[]{"WSO23", 70f, null, 40L, 10, 1496289950090L});
+
+            // Thursday, June 1, 2017 4:05:54 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 101f, null, 200L, 26, 1496289954000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 102f, null, 200L, 100, 1496289954000L});
+
+            // Thursday, June 1, 2017 4:05:56 AM
+            stockStreamInputHandler.send(new Object[]{"IBM", 900f, null, 200L, 60, 1496289956000L});
+            stockStreamInputHandler.send(new Object[]{"IBM1", 500f, null, 200L, 7, 1496289956000L});
+
+            Thread.sleep(100);
+
+            inputStreamInputHandler.send(new Object[]{"IBM"});
+            Thread.sleep(100);
+
+            List<Object[]> expected = Arrays.asList(
+                    new Object[]{"WSO22", 75.0},
+                    new Object[]{"WSO2", 50.0},
+                    new Object[]{"WSO23", 130.0},
+                    new Object[]{"WSO24", 100.0},
+                    new Object[]{"IBM1", 602.0},
+                    new Object[]{"IBM", 1001.0}
+            );
+            SiddhiTestHelper.waitForEvents(100, 6, inEventCount, 10000);
+
+            AssertJUnit.assertTrue("Event arrived", eventArrived);
+            AssertJUnit.assertEquals("Number of success events", 6, inEventCount.get());
+            AssertJUnit.assertTrue("In events matched",
+                    SiddhiTestHelper.isUnsortedEventsMatch(inEventsList, expected));
+
+        } finally {
+            siddhiAppRuntime.shutdown();
+        }
+    }
+
+}

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
@@ -168,7 +168,7 @@ public class SelectOptimisationAggregationTestCaseIT {
         }
     }
 
-    @Test( dependsOnMethods = "aggregationFunctionTestcase1")
+    @Test(dependsOnMethods = "aggregationFunctionTestcase1")
     public void aggregationFunctionTestcase2() throws InterruptedException {
         LOG.info("aggregationFunctionTestcase1 - external timestamp count w/o group by");
         SiddhiManager siddhiManager = new SiddhiManager();
@@ -559,8 +559,8 @@ public class SelectOptimisationAggregationTestCaseIT {
         SiddhiManager siddhiManager = new SiddhiManager();
 
         String stockStream =
-                "define stream stockStream (symbol string, name string, price float, lastClosingPrice float, volume long , " +
-                        "quantity int, timestamp long);";
+                "define stream stockStream (symbol string, name string, price float, lastClosingPrice float, " +
+                        "volume long , quantity int, timestamp long);";
         String query =
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
@@ -609,7 +609,7 @@ public class SelectOptimisationAggregationTestCaseIT {
 
             // Thursday, June 1, 2017 4:05:52 AM
             stockStreamInputHandler.send(new Object[]{"WSO2", "WSO21", 60f, 44f, 200L, 56, 1496289952000L});
-            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22",100f, null, 200L, 16, 1496289952000L});
+            stockStreamInputHandler.send(new Object[]{"WSO2", "WSO22", 100f, null, 200L, 16, 1496289952000L});
 
             // Thursday, June 1, 2017 4:05:54 AM
             stockStreamInputHandler.send(new Object[]{"IBM", "IBM1", 100f, null, 200L, 26, 1496289954000L});
@@ -1180,24 +1180,24 @@ public class SelectOptimisationAggregationTestCaseIT {
                         "quantity int, timestamp long);";
         String query =
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
-                        "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                        "\", pool.properties=\"maximumPoolSize:1\")\n" +
-                        "@purge(enable='false')" +
-                        "define aggregation stockAggregation " +
-                        "from stockStream " +
-                        "select symbol, sum(price) as sumPrice " +
-                        "group by symbol " +
-                        "aggregate by timestamp every sec...min ;" +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "@purge(enable='false')" +
+                "define aggregation stockAggregation " +
+                "from stockStream " +
+                "select symbol, sum(price) as sumPrice " +
+                "group by symbol " +
+                "aggregate by timestamp every sec...min ;" +
 
-                        "define stream inputStream (symbol string); " +
+                "define stream inputStream (symbol string); " +
 
-                        "@info(name = 'query1') " +
-                        "from inputStream as i join stockAggregation as s " +
-                        "within 1496200000000L, 1596535449000L " +
-                        "per \"seconds\" " +
-                        "select s.symbol, sum(s.sumPrice) as sumPrice " +
-                        "group by i.symbol, s.symbol " +
-                        "insert all events into outputStream; ";
+                "@info(name = 'query1') " +
+                "from inputStream as i join stockAggregation as s " +
+                "within 1496200000000L, 1596535449000L " +
+                "per \"seconds\" " +
+                "select s.symbol, sum(s.sumPrice) as sumPrice " +
+                "group by i.symbol, s.symbol " +
+                "insert all events into outputStream; ";
 
         SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(stockStream + query);
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/set/SetUpdateOrInsertRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/set/SetUpdateOrInsertRDBMSTableTestCaseIT.java
@@ -77,7 +77,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -122,7 +123,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -167,7 +169,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -214,7 +217,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -261,7 +265,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -306,7 +311,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -351,7 +357,8 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -395,7 +402,7 @@ public class SetUpdateOrInsertRDBMSTableTestCaseIT {
                 "define stream UpdateStockStream (symbol string, price int, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
                 "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
-                "\", field.length=\"symbol:100\")\n" +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
                 "@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price int, volume long); ";

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/set/SetUpdateRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/set/SetUpdateRDBMSTableTestCaseIT.java
@@ -69,7 +69,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -114,7 +115,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -159,7 +161,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -206,7 +209,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -254,7 +258,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -300,7 +305,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";
@@ -345,7 +351,8 @@ public class SetUpdateRDBMSTableTestCaseIT {
                     "define stream StockStream (symbol string, price float, volume long); " +
                     "define stream UpdateStockStream (symbol string, price float, volume long); " +
                     "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\", " +
-                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\")\n" +
+                    "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\", " +
+                    "pool.properties=\"maximumPoolSize:1\")\n" +
                     //"@PrimaryKey(\"symbol\")" +
                     //"@Index(\"volume\")" +
                     "define table StockTable (symbol string, price float, volume long); ";

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -38,7 +38,9 @@
         <classes>
             <class name="io.siddhi.extension.store.rdbms.aggregation.InitialiseExecutorsAggregationTestCaseIT" />
             <class name="io.siddhi.extension.store.rdbms.aggregation.AggregationFilterTestCaseIT" />
+            <class name="io.siddhi.extension.store.rdbms.aggregation.LatestAggregationTestCaseIT" />
             <class name="io.siddhi.extension.store.rdbms.aggregation.DistributedAggregationTestCaseIT" />
+            <class name="io.siddhi.extension.store.rdbms.aggregation.SelectOptimisationAggregationTestCaseIT" />
         </classes>
     </test>
 </suite>

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -36,7 +36,7 @@
     </test>
     <test name="Aggregation test cases">
         <classes>
-            <class name="io.siddhi.extension.store.rdbms.aggregation.IncrementalAggregationTestCaseIT" />
+            <class name="io.siddhi.extension.store.rdbms.aggregation.InitialiseExecutorsAggregationTestCaseIT" />
             <class name="io.siddhi.extension.store.rdbms.aggregation.AggregationFilterTestCaseIT" />
             <class name="io.siddhi.extension.store.rdbms.aggregation.DistributedAggregationTestCaseIT" />
         </classes>

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -161,16 +161,10 @@
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>integration-test-for-mysql</id>
-                        <phase>integration-test</phase>
-                        <goals>
-                            <goal>integration-test</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>verify-for-mysql</id>
+                        <id>verify-for-h2</id>
                         <phase>verify</phase>
                         <goals>
+                            <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
                     </execution>


### PR DESCRIPTION
## Purpose
Support incrementmental:last() function at DB level for optimisation.

## Goals
Support incrementmental:last(symbol, AGG_LAST_EVENT_TIMESTAMP) implies,
```
select symbol where AGG_LAST_EVENT_TIMSSTAMP is max
```

## Approach
The final aggregation lookup query will be as follows, 
```
SELECT 
    MAX(t2.AGG_TIMESTAMP) AS AGG_TIMESTAMP,
    stockAggregation_SECONDS.symbol AS symbol,
    MAX(stockAggregation_SECONDS.lastTradeValue) AS lastTradeValue,
    MAX(t2.AGG_SUM_price) AS AGG_SUM_price,
    MAX(t2.AGG_COUNT) AS AGG_COUNT
FROM
    stockAggregation_SECONDS,
    (SELECT 
        MAX(stockAggregation_SECONDS.AGG_TIMESTAMP) AS AGG_TIMESTAMP,
        stockAggregation_SECONDS.symbol AS symbol,
        MAX(stockAggregation_SECONDS.AGG_TIMESTAMP) AS MAX_AGG_TIMESTAMP,
        SUM(stockAggregation_SECONDS.AGG_SUM_price) AS AGG_SUM_price,
        SUM(stockAggregation_SECONDS.AGG_COUNT) AS AGG_COUNT
    FROM
        stockAggregation_SECONDS
    GROUP BY stockAggregation_SECONDS.symbol) AS t2
WHERE
    stockAggregation_SECONDS.symbol = t2.symbol
        AND stockAggregation_SECONDS.AGG_TIMESTAMP = t2.MAX_AGG_TIMESTAMP
GROUP BY stockAggregation_SECONDS.symbol
```
Original Aggregation Group by: AGG_TIMESTAMP, symbol
Query Group by : symbol

## Documentation
N/A

## Automation tests
 - Unit tests 
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Related PRs
https://github.com/siddhi-io/siddhi/pull/1339

## Test environment
JDK1.8_201
DBs: H2, MySQL, MSSQL, Postgres, Oracle 11-xe, Oracle12-se
