### PR TITLE
[Execution-rdbms] Add support for Siddhi level data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For information on <a target="_blank" href="https://siddhi.io/">Siddhi</a> and i
 
 ## Download
 
-* Versions 6.x and above with group id `io.siddhi.extension.*` from <a target="_blank" href="https://mvnrepository.com/artifact/io.siddhi.extension.store.rdbms/siddhi-store-rdbms/">here</a>.
+* Versions 7.x & 6.x and above with group id `io.siddhi.extension.*` from <a target="_blank" href="https://mvnrepository.com/artifact/io.siddhi.extension.store.rdbms/siddhi-store-rdbms/">here</a>.
 * Versions 5.x and lower with group id `org.wso2.extension.siddhi.*` from <a target="_blank" href="https://mvnrepository.com/artifact/org.wso2.extension.siddhi.store.rdbms/siddhi-store-rdbms">here</a>.
 
 ## Latest API Docs 

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.rdbms</groupId>
         <artifactId>siddhi-store-rdbms-parent</artifactId>
-        <version>6.0.5-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
@@ -46,7 +46,6 @@ import io.siddhi.query.api.definition.AbstractDefinition;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -54,6 +53,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.sql.DataSource;
 
 /**
  * This extension can be used to perform SQL CUD (INSERT, UPDATE, DELETE) queries on a datasource.

--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
@@ -75,7 +75,8 @@ import java.util.List;
                         name = "query",
                         description = "The update, delete, or insert query(formatted according to " +
                                 "the relevant database type) that needs to be performed.",
-                        type = DataType.STRING
+                        type = DataType.STRING,
+                        dynamic = true
                 ),
                 @Parameter(
                         name = "parameter",
@@ -84,7 +85,8 @@ import java.util.List;
                         type = {DataType.STRING, DataType.BOOL, DataType.INT, DataType.DOUBLE, DataType.FLOAT,
                                 DataType.LONG},
                         optional = true,
-                        defaultValue = "<Empty_String>"
+                        defaultValue = "<Empty_String>",
+                        dynamic = true
                 )
         },
         parameterOverloads = {
@@ -143,7 +145,7 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
     private String dataSourceName;
     private DataSource dataSource;
     private ExpressionExecutor queryExpressionExecutor;
-    private boolean isVaryingQuery;
+    private boolean isQueryParameterised;
     private List<ExpressionExecutor> expressionExecutors = new ArrayList<>();
     private List<Attribute> attributeList = new ArrayList<>();
 
@@ -158,43 +160,32 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
         if (!performCUDOps) {
             throw new SiddhiAppValidationException("Performing CUD operations through " +
                     "rdbms cud function is disabled. This is configured through system parameter, " +
-                    "'perform.CUD.operations' in '<SP_HOME>/conf/<profile>/deployment.yaml'");
-        }
-
-        if ((attributeExpressionExecutors.length < 2)) {
-            throw new SiddhiAppValidationException("rdbms cud function " +
-                    "should have 2 parameters , but found '" + attributeExpressionExecutors.length + "' parameters.");
+                    "'perform.CUD.operations' in '<SIDDHI_HOME>/conf/<profile>/deployment.yaml'");
         }
 
         this.dataSourceName = RDBMSStreamProcessorUtil.validateDatasourceName(attributeExpressionExecutors[0]);
+        this.siddhiContext = siddhiQueryContext.getSiddhiAppContext().getSiddhiContext();
 
-        if (attributeExpressionExecutors[1].getReturnType() == Attribute.Type.STRING) {
-            queryExpressionExecutor = attributeExpressionExecutors[1];
-        } else {
-            throw new SiddhiAppValidationException("The parameter 'query' in rdbms cud " +
-                    "function should be of type STRING, but found a parameter with type '" +
-                    attributeExpressionExecutors[1].getReturnType() + "'.");
-        }
-
+        this.queryExpressionExecutor = attributeExpressionExecutors[1];
         if (attributeExpressionExecutors.length > 2) {
-            this.isVaryingQuery = true;
+            this.isQueryParameterised = true;
+            this.expressionExecutors.addAll(
+                    Arrays.asList(attributeExpressionExecutors).subList(2, attributeExpressionExecutors.length));
+
             //Process the query conditions through stream attributes
             long attributeCount;
             if (queryExpressionExecutor instanceof ConstantExpressionExecutor) {
                 String query = ((ConstantExpressionExecutor) queryExpressionExecutor).getValue().toString();
                 attributeCount = query.chars().filter(ch -> ch == '?').count();
+                if (attributeCount != attributeExpressionExecutors.length - 2) {
+                    throw new SiddhiAppValidationException("The parameter 'query' in rdbms query function contains '" +
+                            attributeCount + "' ordinals, but found siddhi attributes of count '" +
+                            (attributeExpressionExecutors.length - 2) + "'.");
+                }
             } else {
                 throw new SiddhiAppValidationException("The parameter 'query' in rdbms query " +
                         "function should be a constant, but found a parameter of instance '" +
                         attributeExpressionExecutors[1].getClass().getName() + "'.");
-            }
-            if (attributeCount == attributeExpressionExecutors.length - 2) {
-                this.expressionExecutors.addAll(
-                        Arrays.asList(attributeExpressionExecutors).subList(2, attributeExpressionExecutors.length));
-            } else {
-                throw new SiddhiAppValidationException("The parameter 'query' in rdbms query " +
-                        "function contains '" + attributeCount + "' ordinals, but found siddhi attributes of count '" +
-                        (attributeExpressionExecutors.length - 2) + "'.");
             }
         }
 
@@ -213,7 +204,7 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
                 StreamEvent event = streamEventChunk.next();
                 String query = ((String) queryExpressionExecutor.execute(event));
                 stmt = conn.prepareStatement(query);
-                if (!streamEventChunk.hasNext() && !isVaryingQuery) {
+                if (!streamEventChunk.hasNext() && !isQueryParameterised) {
                     stmt.addBatch();
                 }
                 if (RDBMSStreamProcessorUtil.queryContainsCheck(query)) {
@@ -224,7 +215,7 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
             streamEventChunk.reset();
             while (streamEventChunk.hasNext()) {
                 StreamEvent event = streamEventChunk.next();
-                if (isVaryingQuery) {
+                if (isQueryParameterised) {
                     if (conn.getAutoCommit()) {
                         //commit transaction manually
                         conn.setAutoCommit(false);

--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
@@ -46,7 +46,6 @@ import io.siddhi.query.api.definition.AbstractDefinition;
 import io.siddhi.query.api.definition.Attribute;
 import io.siddhi.query.api.exception.SiddhiAppValidationException;
 
-import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -55,6 +54,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.sql.DataSource;
 
 /**
  * This extension function can be used to perform SQL retrieval queries on a datasource.

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -154,7 +154,7 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableUtils.processFindCo
         name = "rdbms",
         namespace = "store",
         description = "This extension assigns data sources and connection instructions to event tables. It also " +
-                "implements read-write operations on connected datasources.",
+                "implements read-write operations on connected data sources.",
         parameters = {
                 @Parameter(name = "jdbc.url",
                         description = "The JDBC URL via which the RDBMS data store is accessed.",
@@ -185,7 +185,7 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableUtils.processFindCo
                         description = "The name of the Carbon datasource that should be used for creating the " +
                                 "connection with the database. If this is found, neither the pool properties nor the " +
                                 "JNDI resource name described above are taken into account and the connection " +
-                                "is attempted via Carbon datasources instead. ",
+                                "is attempted via Carbon datasources instead. Only works in Siddhi Distribution ",
                         type = {DataType.STRING},
                         optional = true,
                         defaultValue = "null"),

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.extension.execution.rdbms;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import io.siddhi.core.util.config.InMemoryConfigManager;
+import io.siddhi.core.util.config.InMemoryConfigReader;
+import io.siddhi.core.util.config.YAMLConfigManager;
+import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.TABLE_NAME;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.password;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.url;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.user;
+
+public class RDBMSCUDTestCase {
+    private static final Logger log = Logger.getLogger(RDBMSCUDTestCase.class);
+    private boolean isEventArrived;
+    private AtomicInteger eventCount;
+    private List<Object[]> actualData;
+
+    @BeforeClass
+    public static void startTest() {
+        log.info("== RDBMS CUD tests started ==");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        log.info("== RDBMS CUD completed ==");
+    }
+
+    @BeforeMethod
+    public void init() {
+        try {
+            RDBMSTableTestUtils.initDatabaseTable(TABLE_NAME);
+            log.info("Test init with url: " + url + " and driverClass: " + driverClassName);
+            isEventArrived = false;
+            eventCount = new AtomicInteger();
+            actualData = new ArrayList<>();
+        } catch (SQLException e) {
+            log.info("Test case ignored due to " + e.getMessage());
+        }
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
+                "username=\"" + user + "\", password=\"" + password + "\", pool.properties=\"maximumPoolSize:1\")" +
+                "define table " + TABLE_NAME + " (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.query("select 'WSO2' as symbol, 80f as price, 100L as volume insert into " + TABLE_NAME);
+        siddhiAppRuntime.query("select 'IBM' as symbol, 180f as price, 200L as volume insert into " + TABLE_NAME);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test()
+    public void rdbmsCUD1() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsCUD1 - Test Update");
+
+        YAMLConfigManager yamlConfigManager = new YAMLConfigManager(
+                "extensions: \n"+
+                "  - extension: \n" +
+                "      namespace: rdbms\n" +
+                "      name: cud\n" +
+                "      properties:\n" +
+                "        perform.CUD.operations: true" );
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setConfigManager(yamlConfigManager);
+
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:cud(\"TEST_DATASOURCE\", \"UPDATE " + TABLE_NAME + " SET " +
+                "`symbol` = 'WSO22' WHERE `symbol` = 'WSO2';\") " +
+                "select numRecords " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                    actualData.add(event.getData());
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO2"});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertEquals(1, eventCount.get(), "Event count did not match");
+        Assert.assertEquals(1, actualData.get(0)[0]);
+
+    }
+}

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
@@ -113,7 +113,7 @@ public class RDBMSCUDTestCase {
         String query = "" +
                 "@info(name = 'query1') " +
                 "from StockStream#rdbms:cud(\"TEST_DATASOURCE\", \"UPDATE " + TABLE_NAME + " SET " +
-                "`symbol` = 'WSO22' WHERE `symbol` = 'WSO2';\") " +
+                "symbol = 'WSO22' WHERE symbol = 'WSO2';\") " +
                 "select numRecords " +
                 "insert into OutputStream ;";
 

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSCUDTestCase.java
@@ -25,8 +25,6 @@ import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.stream.output.StreamCallback;
 import io.siddhi.core.util.EventPrinter;
 import io.siddhi.core.util.SiddhiTestHelper;
-import io.siddhi.core.util.config.InMemoryConfigManager;
-import io.siddhi.core.util.config.InMemoryConfigReader;
 import io.siddhi.core.util.config.YAMLConfigManager;
 import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
 import org.apache.log4j.Logger;
@@ -36,12 +34,11 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.sql.DataSource;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
 
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.TABLE_NAME;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
@@ -97,12 +94,12 @@ public class RDBMSCUDTestCase {
         log.info("rdbmsCUD1 - Test Update");
 
         YAMLConfigManager yamlConfigManager = new YAMLConfigManager(
-                "extensions: \n"+
+                "extensions: \n" +
                 "  - extension: \n" +
                 "      namespace: rdbms\n" +
                 "      name: cud\n" +
                 "      properties:\n" +
-                "        perform.CUD.operations: true" );
+                "        perform.CUD.operations: true");
 
         SiddhiManager siddhiManager = new SiddhiManager();
         siddhiManager.setConfigManager(yamlConfigManager);

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.siddhi.extension.execution.rdbms;
+
+import com.zaxxer.hikari.HikariDataSource;
+import io.siddhi.core.SiddhiAppRuntime;
+import io.siddhi.core.SiddhiManager;
+import io.siddhi.core.event.Event;
+import io.siddhi.core.stream.input.InputHandler;
+import io.siddhi.core.stream.output.StreamCallback;
+import io.siddhi.core.util.EventPrinter;
+import io.siddhi.core.util.SiddhiTestHelper;
+import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.sql.DataSource;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.TABLE_NAME;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.password;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.url;
+import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.user;
+
+public class RDBMSQueryTestCase {
+    private static final Logger log = Logger.getLogger(RDBMSQueryTestCase.class);
+    private boolean isEventArrived;
+    private AtomicInteger eventCount;
+    private List<Object[]> actualData;
+
+    @BeforeClass
+    public static void startTest() {
+        log.info("== RDBMS Query tests started ==");
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        log.info("== RDBMS Query completed ==");
+    }
+
+    @BeforeMethod
+    public void init() {
+        try {
+            RDBMSTableTestUtils.initDatabaseTable(TABLE_NAME);
+            log.info("Test init with url: " + url + " and driverClass: " + driverClassName);
+            isEventArrived = false;
+            eventCount = new AtomicInteger();
+            actualData = new ArrayList<>();
+        } catch (SQLException e) {
+            log.info("Test case ignored due to " + e.getMessage());
+        }
+
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
+                "username=\"" + user + "\", password=\"" + password + "\", pool.properties=\"maximumPoolSize:1\")" +
+                "define table " + TABLE_NAME + " (symbol string, price float, volume long); ";
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams);
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.query("select 'WSO2' as symbol, 80f as price, 100L as volume insert into " + TABLE_NAME);
+        siddhiAppRuntime.query("select 'IBM' as symbol, 180f as price, 200L as volume insert into " + TABLE_NAME);
+
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test()
+    public void rdbmsQuery1() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + "\") " +
+                "select symbol, price, volume " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO2"});
+        SiddhiTestHelper.waitForEvents(2000, 2, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = Arrays.asList(
+                new Object[]{"WSO2", 80f, 100L},
+                new Object[]{"IBM", 180f, 200L}
+        );
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match");
+
+    }
+
+    @Test(dependsOnMethods = "rdbmsQuery1")
+    public void rdbmsQuery2() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select dynamic query");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string, query String); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "query) " +
+                "select symbol, price, volume " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO2", "select * from " + TABLE_NAME + ""});
+        SiddhiTestHelper.waitForEvents(2000, 2, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = Arrays.asList(
+                new Object[]{"WSO2", 80f, 100L},
+                new Object[]{"IBM", 180f, 200L}
+        );
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match");
+    }
+
+
+    @Test(dependsOnMethods = "rdbmsQuery2")
+    public void rdbmsQuery3() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select parameterised query");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string, query String); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=?\", 'WSO2') " +
+                "select symbol, price, volume " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO2", "select * from " + TABLE_NAME + ""});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = new ArrayList<>();
+        expected.add(new Object[]{"WSO2", 80f, 100L});
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
+    }
+
+
+
+    @Test(dependsOnMethods = "rdbmsQuery3")
+    public void rdbmsQuery4() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select parameterised query");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string, query String); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=?\", checkSymbol) " +
+                "select symbol, price, volume " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO2", "select * from " + TABLE_NAME + ""});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = new ArrayList<>();
+        expected.add(new Object[]{"WSO2", 80f, 100L});
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
+    }
+
+}

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
@@ -33,13 +33,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.sql.DataSource;
-
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.sql.DataSource;
 
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.TABLE_NAME;
 import static io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils.driverClassName;
@@ -232,7 +231,6 @@ public class RDBMSQueryTestCase {
         Assert.assertTrue(isEventArrived, "Event Not Arrived");
         Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
     }
-
 
 
     @Test(dependsOnMethods = "rdbmsQuery3")

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/DefineRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/DefineRDBMSTableTestCaseIT.java
@@ -635,7 +635,7 @@ public class DefineRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
                 "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\"," +
-                "pool.properties=\"maximumPoolSize:50,maxWSO2:60000\")\n" +
+                "pool.properties=\"maximumPoolSize:5,maxWSO2:60000\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";
@@ -671,7 +671,7 @@ public class DefineRDBMSTableTestCaseIT {
                 "define stream StockStream (symbol string, price float, volume long); " +
                 "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", jdbc.driver.name=\"" + driverClassName + "\"," +
                 "username=\"" + user + "\", password=\"" + password + "\",field.length=\"symbol:100\"," +
-                "pool.properties=\"maximumPoolSize:50, maxLifetime:WSO2\")\n" +
+                "pool.properties=\"maximumPoolSize:5, maxLifetime:WSO2\")\n" +
                 //"@PrimaryKey(\"symbol\")" +
                 //"@Index(\"volume\")" +
                 "define table StockTable (symbol string, price float, volume long); ";

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/util/RDBMSTableTestUtils.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/util/RDBMSTableTestUtils.java
@@ -86,7 +86,7 @@ public class RDBMSTableTestUtils {
         return testDataSource;
     }
 
-    private static DataSource initDataSource() {
+    public static DataSource initDataSource() {
         String databaseType = System.getenv("DATABASE_TYPE");
         if (databaseType == null) {
             databaseType = TestType.H2.toString();
@@ -141,7 +141,7 @@ public class RDBMSTableTestUtils {
         connectionProperties.setProperty("dataSource.user", user);
         connectionProperties.setProperty("dataSource.password", password);
         connectionProperties.setProperty("poolName", "Test_Pool");
-        connectionProperties.setProperty("maximumPoolSize", "10");
+        connectionProperties.setProperty("maximumPoolSize", "4");
         HikariConfig config = new HikariConfig(connectionProperties);
         return new HikariDataSource(config);
     }

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -43,4 +43,11 @@
             <class name="io.siddhi.extension.store.rdbms.aggregation.SelectOptimisationAggregationTestCaseIT" />
         </classes>
     </test>
+
+    <test name="Aggregation test cases" parallel="false">
+        <classes>
+            <class name="io.siddhi.extension.execution.rdbms.RDBMSQueryTestCase" />
+            <class name="io.siddhi.extension.execution.rdbms.RDBMSCUDTestCase" />
+        </classes>
+    </test>
 </suite>

--- a/component/src/test/resources/testng.xml
+++ b/component/src/test/resources/testng.xml
@@ -20,7 +20,7 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="Generic Integration test suite">
-    <test name="org.wso2.das">
+    <test name="siddhi-store-rdbms">
         <classes>
             <class name="io.siddhi.extension.store.rdbms.DefineRDBMSTableTestCaseIT" />
             <class name="io.siddhi.extension.store.rdbms.DeleteFromRDBMSTableTestCaseIT" />
@@ -44,7 +44,7 @@
         </classes>
     </test>
 
-    <test name="Aggregation test cases" parallel="false">
+    <test name="rdbms-query-test-cases" parallel="false">
         <classes>
             <class name="io.siddhi.extension.execution.rdbms.RDBMSQueryTestCase" />
             <class name="io.siddhi.extension.execution.rdbms.RDBMSCUDTestCase" />

--- a/coverage-reports/pom.xml
+++ b/coverage-reports/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.rdbms</groupId>
         <artifactId>siddhi-store-rdbms-parent</artifactId>
-        <version>6.0.5-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>io.siddhi.extension.store.rdbms</groupId>
     <artifactId>siddhi-store-rdbms-parent</artifactId>
-    <version>6.0.5-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>WSO2 Siddhi Store Extension - RDBMS Aggregator Pom</name>
     <url>http://wso2.org</url>

--- a/tests/distribution/pom.xml
+++ b/tests/distribution/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.rdbms</groupId>
         <artifactId>siddhi-store-rdbms-tests</artifactId>
-        <version>6.0.5-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/osgi-tests/pom.xml
+++ b/tests/osgi-tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.rdbms</groupId>
         <artifactId>siddhi-store-rdbms-tests</artifactId>
-        <version>6.0.5-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.siddhi.extension.store.rdbms</groupId>
         <artifactId>siddhi-store-rdbms-parent</artifactId>
-        <version>6.0.5-SNAPSHOT</version>
+        <version>7.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
## Purpose
1. rdbms:query() and dbms:cud() cannot be used in java/python libraries
2. Parameter validation fails due to `parameter` being supported one or more times in rdbms:query()

## Goals
1. Add dupport to use datasources set at siddhi manager level, fixes https://github.com/siddhi-io/siddhi/issues/1509
2. Reorder parameters as follows, 
```
query('datasource.name', 'attribute.definition.list', 'query', 'parameter', ...)
```

## Approach
1. Look for the data source in siddhi context at the execution start
2. As in 48b9274

## Release note
Add support for Siddhi data sources

## Documentation
Attached herewith

## Automation tests
 - Unit tests - Attached herewith
 - Integration tests - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Migrations (if applicable)
rdbms:query() definitions should be changed such that the last parameter is now the second parameter
Before: ```query('datasource.name', 'query', 'parameter', ..., 'attribute.definition.list')```
After: ```query('datasource.name', 'attribute.definition.list', 'query', 'parameter', ...)```

## Test environment
JDK 1.8.0_191 and relevant databases supported