### PR TITLE
Add dependencies as private package required for JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@
 
 language: java
 
+jdk:
+  - openjdk8
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,9 @@ cache:
   bundler: true
   directories:
     - $HOME/.m2
+    - "$HOME/apache-maven-3.5.3"
+
+before_install:
+  - export M2_HOME=$HOME/apache-maven-3.5.3
+  - if [ ! -d $M2_HOME/bin ]; then curl https://archive.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.tar.gz | tar zxf - -C $HOME; fi
+  - export PATH=$M2_HOME/bin:$PATH

--- a/component/pom.xml
+++ b/component/pom.xml
@@ -53,6 +53,22 @@
             <artifactId>commons-logging</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wso2.carbon.datasources</groupId>
             <artifactId>org.wso2.carbon.datasource.core</artifactId>
         </dependency>
@@ -132,6 +148,11 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
                             !com.zaxxer.hikari.*,
+                            com.sun.istack.*,
+                            com.sun.xml.*,
+                            javax.xml.*,
+                            com.sun.activation.*,
+                            javax.activation.*
                         </Private-Package>
                         <Export-Package>
                             !com.zaxxer.hikari.*,

--- a/component/src/main/resources/META-INF/mailcap.default
+++ b/component/src/main/resources/META-INF/mailcap.default
@@ -1,0 +1,7 @@
+#
+# This is a very simple 'mailcap' file
+#
+image/gif;;		x-java-view=com.sun.activation.viewers.ImageViewer
+image/jpeg;;		x-java-view=com.sun.activation.viewers.ImageViewer
+text/*;;		x-java-view=com.sun.activation.viewers.TextViewer
+text/*;;		x-java-edit=com.sun.activation.viewers.TextEditor

--- a/component/src/main/resources/META-INF/mimetypes.default
+++ b/component/src/main/resources/META-INF/mimetypes.default
@@ -1,0 +1,25 @@
+#
+# A simple, old format, mime.types file
+#
+text/html		html htm HTML HTM
+text/plain		txt text TXT TEXT
+image/gif		gif GIF
+image/ief		ief
+image/jpeg		jpeg jpg jpe JPG
+image/tiff		tiff tif
+image/png		png PNG
+image/x-xwindowdump	xwd
+application/postscript	ai eps ps
+application/rtf		rtf
+application/x-tex	tex
+application/x-texinfo	texinfo texi
+application/x-troff	t tr roff
+audio/basic		au
+audio/midi		midi mid
+audio/x-aifc		aifc
+audio/x-aiff            aif aiff
+audio/x-mpeg		mpeg mpg
+audio/x-wav             wav
+video/mpeg		mpeg mpg mpe
+video/quicktime		qt mov
+video/x-msvideo		avi

--- a/component/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
+++ b/component/src/main/resources/META-INF/services/javax.xml.bind.JAXBContext
@@ -1,0 +1,1 @@
+com.sun.xml.bind.v2.ContextFactory

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,8 @@
         <sqljdbc4.version>4.0</sqljdbc4.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.fabric8.version>0.20.0</io.fabric8.version>
+        <jaxb.version>2.2.11</jaxb.version>
+        <javax.annotation.version>1.1.1</javax.annotation.version>
     </properties>
 
     <scm>
@@ -451,6 +453,26 @@
                 <version>${commons.io.version}</version>
             </dependency>
             <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javax.activation</groupId>
+                <artifactId>activation</artifactId>
+                <version>${javax.annotation.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon</groupId>
                 <artifactId>osgi-test-util</artifactId>
                 <version>${osgi.test.util.version}</version>
@@ -498,8 +520,6 @@
                 <version>${carbon.analytics.common.version}</version>
                 <type>zip</type>
             </dependency>
-
-
             <dependency>
                 <groupId>io.siddhi.distribution</groupId>
                 <artifactId>io.siddhi.distribution.msf4j.interceptor.common.feature</artifactId>


### PR DESCRIPTION
## Purpose
> Add dependencies as private package required for JDK 11
> Travis updates to run with Maven 3.5.x and JDK 1.8 ....

