### PR TITLE
Introduce 'use.collation' property to enable binary collation

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSQueryConfigurationEntry.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSQueryConfigurationEntry.java
@@ -47,6 +47,7 @@ public class RDBMSQueryConfigurationEntry {
     private RDBMSSelectQueryTemplate rdbmsSelectQueryTemplate;
     private int batchSize;
     private boolean batchEnable = false;
+    private String collation;
     private boolean transactionSupported = true;
     private String recordContainsCondition;
 
@@ -89,6 +90,15 @@ public class RDBMSQueryConfigurationEntry {
 
     public void setBatchEnable(boolean batchEnable) {
         this.batchEnable = batchEnable;
+    }
+
+    @XmlElement(name = "collation")
+    public String getCollation() {
+        return collation;
+    }
+
+    public void setCollation(String collation) {
+        this.collation = collation;
     }
 
     public void setCategory(String category) {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -62,6 +62,7 @@ public class RDBMSTableConstants {
     public static final String SQL_NOT_NULL = "NOT NULL";
     public static final String SQL_PRIMARY_KEY_DEF = "PRIMARY KEY";
     public static final String SQL_WHERE = "WHERE";
+    public static final String SQL_COLLATE = "COLLATE";
     public static final String SQL_AS = " AS ";
     public static final String SQL_MAX = "MAX"; // Used for incrementalAggregator:last()
     public static final String WHITESPACE = " ";
@@ -112,6 +113,7 @@ public class RDBMSTableConstants {
     public static final String BATCH_SIZE = "batchSize";
     public static final String FIELD_SIZE_LIMIT = "fieldSizeLimit";
     public static final String BATCH_ENABLE = "batchEnable";
+    public static final String COLLATION = "collation";
     public static final String TRANSACTION_SUPPORTED = "transactionSupported";
     public static final String SELECT_QUERY_TEMPLATE = "selectQueryTemplate";
     public static final String SELECT_QUERY_WITH_SUB_SELECT_TEMPLATE = "selectQueryWithSubSelect";
@@ -127,6 +129,8 @@ public class RDBMSTableConstants {
     public static final String LIMIT_WRAPPER_CLAUSE = "limitWrapperClause";
     public static final String OFFSET_WRAPPER_CLAUSE = "offsetWrapperClause";
     public static final String MICROSOFT_SQL_SERVER_NAME = "Microsoft SQL Server";
+
+    public static final String USE_COLLATION = "use.collation";
 
     private RDBMSTableConstants() {
         //preventing initialization

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -68,6 +68,7 @@
             <longType>BIGINT</longType>
             <stringType>VARCHAR</stringType>
         </typeMapping>
+        <collation>latin1_bin</collation>
     </database>
     <database name="oracle" maxVersion = "12.0">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
@@ -177,6 +178,7 @@
             <longType>BIGINT</longType>
             <stringType>VARCHAR</stringType>
         </typeMapping>
+        <collation>SQL_Latin1_General_CP1_CS_AS</collation>
     </database>
     <database name="PostgreSQL">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>


### PR DESCRIPTION

## Documentation
In order to use collation, set 'use.collation' property to true in siddhi store configuration.

@store( type="rdbms",
        jdbc.url="jdbc:mysql://localhost:3306/sweetFactoryDB?useSSL=false",
        username="abc",
        password="abc",
        use.collation='true',
        jdbc.driver.name="com.mysql.jdbc.Driver")
@primaryKey('id','volume') 
define table MyTable (id string, volume int);

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

