### PR TITLE
Fix Is Null check in having clause fails

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -246,7 +246,7 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
 
     @Override
     public void endVisitIsNull(String streamId) {
-        if (!this.isAfterSelectClause) {
+        if (this.isAfterSelectClause) {
            throw new OperationNotSupportedException("The RDBMS Event table does not support 'IS NULL' functions " +
                    "in having clause.");
         }

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSConditionVisitor.java
@@ -246,6 +246,10 @@ public class RDBMSConditionVisitor extends BaseExpressionVisitor {
 
     @Override
     public void endVisitIsNull(String streamId) {
+        if (!this.isAfterSelectClause) {
+           throw new OperationNotSupportedException("The RDBMS Event table does not support 'IS NULL' functions " +
+                   "in having clause.");
+        }
         condition.append(RDBMSTableConstants.SQL_IS_NULL).append(WHITESPACE);
     }
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/JoinRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/JoinRDBMSTableTestCaseIT.java
@@ -1160,4 +1160,66 @@ public class JoinRDBMSTableTestCaseIT {
         Assert.assertEquals(eventArrived, true, "Event arrived");
         siddhiAppRuntime.shutdown();
     }
+
+    @Test
+    public void testIsNullInHavingClause() throws InterruptedException {
+        log.info("testIsNullInHavingClause");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long); " +
+                "define stream CheckStockStream (symbol string, volume long); " +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", " +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\", pool.properties=\"maximumPoolSize:1\")\n" +
+                "define table StockTable (symbol string, price float, volume long); ";
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream " +
+                "insert into StockTable ;" +
+                "" +
+                "@info(name = 'query2') " +
+                "from CheckStockStream left outer join StockTable " +
+                "on StockTable.symbol == CheckStockStream.symbol " +
+                "select CheckStockStream.symbol as checkSymbol, StockTable.symbol as symbol " +
+                "having symbol is null " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("query2", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                if (inEvents != null) {
+                    for (Event event : inEvents) {
+                        inEventCount++;
+                        if (inEventCount == 1) {
+                            Assert.assertEquals(event.getData(), new Object[]{"WSO2", null});
+                        } else {
+                            Assert.fail();
+                        }
+                    }
+                    eventArrived = true;
+                }
+                if (removeEvents != null) {
+                    removeEventCount = removeEventCount + removeEvents.length;
+                }
+                eventArrived = true;
+            }
+
+        });
+
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        InputHandler checkStockStream = siddhiAppRuntime.getInputHandler("CheckStockStream");
+        siddhiAppRuntime.start();
+
+        checkStockStream.send(new Object[]{"WSO2", 50L});
+        stockStream.send(new Object[]{"WSO2", 55.6f, 100L});
+        checkStockStream.send(new Object[]{"WSO2", 50L});
+        Thread.sleep(1000);
+
+        Assert.assertTrue(eventArrived, "Event arrived");
+        Assert.assertEquals(inEventCount, 1, "Number of success events");
+        Assert.assertEquals(removeEventCount, 0, "Number of remove events");
+        siddhiAppRuntime.shutdown();
+    }
 }

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/query/StoreQueryTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/query/StoreQueryTableTestCaseIT.java
@@ -966,9 +966,8 @@ public class StoreQueryTableTestCaseIT {
         Assert.assertEquals(allEvents[0].getData()[0], 2);
     }
 
-    @Test(enabled = false)
+    @Test
     public void test22() throws InterruptedException {
-        // Fix for the test case is in https://github.com/siddhi-io/siddhi/pull/1382
         log.info("Test9 table");
 
         SiddhiManager siddhiManager = new SiddhiManager();


### PR DESCRIPTION
## Purpose
$subject fix https://github.com/siddhi-io/siddhi-store-rdbms/issues/207

## Approach
Revert to find method if is null check is in having clause

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes