### PR TITLE
Ignore field.length validation for Named aggregation SHARD_ID column

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -1516,7 +1516,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
         List<String> attributeNames = new ArrayList<>();
         this.attributes.forEach(attribute -> attributeNames.add(attribute.getName()));
         fieldLengths.keySet().forEach(field -> {
-            if (!attributeNames.contains(field)) {
+            if (!field.equals(SiddhiConstants.AGG_SHARD_ID_COL) && !attributeNames.contains(field)) {
                 throw new RDBMSTableException("Field '" + field + "' (for which a size of " + fieldLengths.get(field)
                         + " has been specified) does not exist in the table's list of fields.");
             }


### PR DESCRIPTION
## Purpose
$subject as this column is injected by the Named aggregation implementation.

## Goals
To suppress 'field.length' validation for columns introduced by the aggregations, since SHARD_ID column is only present when distributed aggregation is enabled.

## Approach
Ignore validation if field.length contains SHARD_ID config

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes