### PR TITLE
Remove the query validation for #rdbms:query.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/CUDStreamProcessor.java
@@ -188,7 +188,7 @@ public class CUDStreamProcessor extends StreamProcessor {
                 if (!streamEventChunk.hasNext() && !isVaryingQuery) {
                     stmt.addBatch();
                 }
-                if (RDBMSStreamProcessorUtil.queryContainsCheck(false, query)) {
+                if (RDBMSStreamProcessorUtil.queryContainsCheck(query)) {
                     throw new SiddhiAppRuntimeException("Dropping event since the query has " +
                             "unauthorised operations, '" + query + "'. Event: '" + event + "'.");
                 }

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/QueryStreamProcessor.java
@@ -245,10 +245,6 @@ public class QueryStreamProcessor extends StreamProcessor {
             while (streamEventChunk.hasNext()) {
                 StreamEvent event = streamEventChunk.next();
                 String query = ((String) queryExpressionExecutor.execute(event));
-                if (RDBMSStreamProcessorUtil.queryContainsCheck(true, query)) {
-                    throw new SiddhiAppRuntimeException("Dropping event since the query has unauthorised operations, " +
-                            "'" + query + "'. Event: '" + event + "'.");
-                }
                 stmt = conn.prepareStatement(query);
                 if (isVaryingQuery) {
                     for (int i = 0; i < this.expressionExecutors.size(); i++) {

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
@@ -141,7 +141,7 @@ public class RDBMSStreamProcessorUtil {
      */
     public static boolean queryContainsCheck(String query) {
         return Arrays.stream(RDBMSStreamProcessorUtil.OPERATIONS)
-                    .parallel().anyMatch(query.toUpperCase(Locale.getDefault())::contains);
+                .parallel().anyMatch(query.toUpperCase(Locale.getDefault())::contains);
     }
 
     /**

--- a/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/execution/rdbms/util/RDBMSStreamProcessorUtil.java
@@ -47,7 +47,6 @@ import java.util.Locale;
 public class RDBMSStreamProcessorUtil {
     private static final Logger LOG = LoggerFactory.getLogger(RDBMSStreamProcessorUtil.class);
     private static final String[] OPERATIONS = new String[]{"DROP", "ALTER"};
-    private static final String[] MANIPULATION_OPERATIONS = new String[]{"INSERT", "UPDATE", "DELETE", "DROP", "ALTER"};
 
     /**
      * Method which can be used to clear up and ephemeral SQL connectivity artifacts.
@@ -137,18 +136,12 @@ public class RDBMSStreamProcessorUtil {
     /**
      * Utility function for validating the query.
      *
-     * @param isRetrievalQuery Is it a retrieval query
      * @param query Query that is to be validated
      * @return true when query has unauthorised operations
      */
-    public static boolean queryContainsCheck(boolean isRetrievalQuery, String query) {
-        if (isRetrievalQuery) {
-            return Arrays.stream(RDBMSStreamProcessorUtil.MANIPULATION_OPERATIONS)
+    public static boolean queryContainsCheck(String query) {
+        return Arrays.stream(RDBMSStreamProcessorUtil.OPERATIONS)
                     .parallel().anyMatch(query.toUpperCase(Locale.getDefault())::contains);
-        } else {
-            return Arrays.stream(RDBMSStreamProcessorUtil.OPERATIONS)
-                    .parallel().anyMatch(query.toUpperCase(Locale.getDefault())::contains);
-        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
> As per the current validation logic for the query, it will go through the whole query for unauthorised table operations, in this case, if there is a string related to the table operations(actually not a table operation can be a value/table name) the prattler query will be failed.
By this RP, this will be resolved.

## Goals
> Resolving the mentioned issue in the ##Purpose
