### PR TITLE
Allow adding null values to rdbms tables

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -222,7 +222,7 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableUtils.processFindCo
                         defaultValue = "The tableCheckQuery which define in store rdbms configs"
                 ),
                 @Parameter(name = "use.collation",
-                        description = "This property allows users to use collation for string attirbutes. By " +
+                        description = "This property allows users to use collation for string attributes. By " +
                                 "default it's false and binary collation is not used. Currently 'latin1_bin' and " +
                                 "'SQL_Latin1_General_CP1_CS_AS' are used as collations for MySQL and " +
                                 "Microsoft SQL database types respectively.",
@@ -600,8 +600,10 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
     private String recordContainsConditionTemplate;
     private RDBMSSelectQueryTemplate rdbmsSelectQueryTemplate;
     private boolean useCollation = false;
+    private boolean allowNullValues = false;
     private String collation;
     private RDBMSMetrics metrics;
+    private RDBMSTypeMapping typeMapping;
 
     @Override
     protected void init(TableDefinition tableDefinition, ConfigReader configReader) {
@@ -609,6 +611,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
         storeAnnotation = AnnotationHelper.getAnnotation(ANNOTATION_STORE, tableDefinition.getAnnotations());
         useCollation = Boolean.parseBoolean(storeAnnotation.getElement(RDBMSTableConstants
                 .USE_COLLATION));
+        allowNullValues = Boolean.parseBoolean(storeAnnotation.getElement(RDBMSTableConstants.ALLOW_NULL));
         primaryKeys = AnnotationHelper.getAnnotation(SiddhiConstants.ANNOTATION_PRIMARY_KEY,
                 tableDefinition.getAnnotations());
         indices = AnnotationHelper.getAnnotations(SiddhiConstants.ANNOTATION_INDEX,
@@ -675,10 +678,10 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 if (rdbmsCompiledCondition.isContainsConditionExist()) {
 
                     RDBMSTableUtils.resolveConditionForContainsCheck(stmt, (RDBMSCompiledCondition) compiledCondition,
-                            findConditionParameterMap, 0);
+                            findConditionParameterMap, 0, typeMapping);
                 } else {
                     RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
-                            findConditionParameterMap, 0);
+                            findConditionParameterMap, 0, typeMapping);
                 }
             }
             rs = stmt.executeQuery();
@@ -713,7 +716,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                     conn.prepareStatement(containsQuery.replace(PLACEHOLDER_CONDITION, "")) :
                     conn.prepareStatement(RDBMSTableUtils.formatQueryWithCondition(containsQuery, condition));
             RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
-                    containsConditionParameterMap, 0);
+                    containsConditionParameterMap, 0, typeMapping);
             rs = stmt.executeQuery();
             return rs.next();
         } catch (SQLException e) {
@@ -751,7 +754,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             int counter = 0;
             for (Map<String, Object> deleteConditionParameterMap : deleteConditionParameterMaps) {
                 RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
-                        deleteConditionParameterMap, 0);
+                        deleteConditionParameterMap, 0, typeMapping);
                 stmt.addBatch();
                 counter++;
                 if (counter == batchSize) {
@@ -836,10 +839,11 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             while (conditionParamIterator.hasNext() && updateSetParameterMapsIterator.hasNext()) {
                 Map<String, Object> conditionParameters = conditionParamIterator.next();
                 Map<String, Object> updateSetMap = updateSetParameterMapsIterator.next();
-                int ordinal = RDBMSTableUtils.enumerateUpdateSetEntries(updateSetExpressions, stmt, updateSetMap);
+                int ordinal = RDBMSTableUtils.enumerateUpdateSetEntries(updateSetExpressions, stmt, updateSetMap,
+                        typeMapping);
                 //Incrementing the ordinals of the conditions in the statement with the # of variables to be updated
                 RDBMSTableUtils.resolveCondition(stmt, (RDBMSCompiledCondition) compiledCondition,
-                        conditionParameters, ordinal - 1);
+                        conditionParameters, ordinal - 1, typeMapping);
                 stmt.addBatch();
                 counter++;
                 if (counter == batchSize) {
@@ -941,10 +945,11 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             while (conditionParamIterator.hasNext() && updateSetMapIterator.hasNext()) {
                 Map<String, Object> conditionParameters = conditionParamIterator.next();
                 Map<String, Object> updateSetMap = updateSetMapIterator.next();
-                int ordinal = RDBMSTableUtils.enumerateUpdateSetEntries(updateSetExpressions, updateStmt, updateSetMap);
+                int ordinal = RDBMSTableUtils.enumerateUpdateSetEntries(updateSetExpressions, updateStmt, updateSetMap,
+                        typeMapping);
                 //Incrementing the ordinals of the conditions in the statement with the # of variables to be updated
                 RDBMSTableUtils.resolveCondition(updateStmt, (RDBMSCompiledCondition) compiledCondition,
-                        conditionParameters, ordinal - 1);
+                        conditionParameters, ordinal - 1, typeMapping);
                 updateStmt.addBatch();
                 if (counter % batchSize == batchSize - 1) {
                     recordInsertIndexList.addAll(this.filterRequiredInsertIndex(updateStmt.executeBatch(),
@@ -996,10 +1001,10 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 Map<String, Object> conditionParameters = updateConditionParameterMaps.get(counter);
                 Map<String, Object> updateSetParameterMap = updateSetParameterMaps.get(counter);
                 int ordinal = RDBMSTableUtils.enumerateUpdateSetEntries(
-                        updateSetExpressions, updateStmt, updateSetParameterMap);
+                        updateSetExpressions, updateStmt, updateSetParameterMap, typeMapping);
                 //Incrementing the ordinals of the conditions in the statement with the # of variables to be updated
                 RDBMSTableUtils.resolveCondition(updateStmt, (RDBMSCompiledCondition) compiledCondition,
-                        conditionParameters, ordinal - 1);
+                        conditionParameters, ordinal - 1, typeMapping);
                 int isUpdate = updateStmt.executeUpdate();
                 conn.commit();
                 if (isUpdate < 1) {
@@ -1234,31 +1239,31 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
                 collation = configReader.readConfig(
                         this.queryConfigurationEntry.getDatabaseName() + PROPERTY_SEPARATOR +
                                 COLLATION, String.valueOf(this.queryConfigurationEntry.getCollation()));
-                RDBMSTypeMapping typeMapping = this.queryConfigurationEntry.getRdbmsTypeMapping();
+                typeMapping = this.queryConfigurationEntry.getRdbmsTypeMapping();
                 booleanType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + BOOLEAN_TYPE,
-                        typeMapping.getBooleanType());
+                        typeMapping.getBooleanType().getTypeName());
                 doubleType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + DOUBLE_TYPE,
-                        typeMapping.getDoubleType());
+                        typeMapping.getDoubleType().getTypeName());
                 floatType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + FLOAT_TYPE,
-                        typeMapping.getFloatType());
+                        typeMapping.getFloatType().getTypeName());
                 integerType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + INTEGER_TYPE,
-                        typeMapping.getIntegerType());
+                        typeMapping.getIntegerType().getTypeName());
                 longType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + LONG_TYPE,
-                        typeMapping.getLongType());
+                        typeMapping.getLongType().getTypeName());
                 binaryType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + BINARY_TYPE,
-                        typeMapping.getBinaryType());
+                        typeMapping.getBinaryType().getTypeName());
                 stringType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + STRING_TYPE,
-                        typeMapping.getStringType());
+                        typeMapping.getStringType().getTypeName());
                 bigStringType = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + TYPE_MAPPING + PROPERTY_SEPARATOR + BIG_STRING_TYPE,
-                        typeMapping.getBigStringType());
+                        typeMapping.getBigStringType() != null ? typeMapping.getBigStringType().getTypeName() : null);
                 stringSize = configReader.readConfig(this.queryConfigurationEntry.getDatabaseName() +
                                 PROPERTY_SEPARATOR + STRING_SIZE,
                         this.queryConfigurationEntry.getStringSize());
@@ -1648,7 +1653,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
      *
      * @param queries    the list of queries to be executed.
      * @param autocommit whether or not the transactions should automatically be committed.
-     * @throws SQLException if the query execution fails.
+     * @throws ConnectionUnavailableException if the query execution fails.
      */
     private void executeDDQueries(List<String> queries, boolean autocommit)
             throws ConnectionUnavailableException {
@@ -1696,7 +1701,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
      * @param query      the query to be executed.
      * @param records    the records to use.
      * @param autocommit whether or not the transactions should automatically be committed.
-     * @throws SQLException if the query execution fails.
+     * @throws ConnectionUnavailableException if the query execution fails.
      */
     private void batchExecuteQueriesWithRecords(String query, List<Object[]> records, boolean autocommit)
             throws ConnectionUnavailableException {
@@ -1825,8 +1830,9 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             for (int i = 0; i < this.attributes.size(); i++) {
                 attribute = this.attributes.get(i);
                 Object value = record[i];
-                if (value != null || attribute.getType() == Attribute.Type.STRING) {
-                    RDBMSTableUtils.populateStatementWithSingleElement(stmt, i + 1, attribute.getType(), value);
+                if (allowNullValues || value != null || attribute.getType() == Attribute.Type.STRING) {
+                    RDBMSTableUtils.populateStatementWithSingleElement(stmt, i + 1, attribute.getType(), value,
+                            typeMapping);
                 } else {
                     throw new RDBMSTableException("Cannot Execute Insert/Update: null value detected for " +
                             "attribute '" + attribute.getName() + "'");
@@ -1870,7 +1876,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
         try {
             stmt = conn.prepareStatement(query);
             RDBMSTableUtils.resolveQuery(stmt, rdbmsCompiledSelection, rdbmsCompiledCondition, parameterMap, 0,
-                    containsConditionExist);
+                    containsConditionExist, typeMapping);
         } catch (SQLException e) {
             try {
                 if (!conn.isValid(0)) {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -228,6 +228,12 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableUtils.processFindCo
                                 "Microsoft SQL database types respectively.",
                         type = {DataType.BOOL},
                         optional = true,
+                        defaultValue = "false"
+                ),
+                @Parameter(name = "allow.null.values",
+                        description = "This property allows users to insert null values to the numeric columns. ",
+                        type = {DataType.BOOL},
+                        optional = true,
                         defaultValue = "false")
         },
         examples = {

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSDataType.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSDataType.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.siddhi.extension.store.rdbms.config;
+
+
+/**
+ * This class represents the SQL datatype and respective int values required by Siddhi RDBMS Event Tables per
+ * supported DB vendor.
+ */
+public class RDBMSDataType {
+    private String typeName;
+    private int typeValue;
+
+    public String getTypeName() {
+        return typeName;
+    }
+
+    public void setTypeName(String typeName) {
+        this.typeName = typeName;
+    }
+
+    public int getTypeValue() {
+        return typeValue;
+    }
+
+    public void setTypeValue(int typeValue) {
+        this.typeValue = typeValue;
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSTypeMapping.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/config/RDBMSTypeMapping.java
@@ -23,76 +23,76 @@ package io.siddhi.extension.store.rdbms.config;
 public class RDBMSTypeMapping {
 
     // -- Type mapping -- //
-    private String binaryType;
-    private String booleanType;
-    private String doubleType;
-    private String floatType;
-    private String integerType;
-    private String longType;
-    private String stringType;
-    private String bigStringType;
+    private RDBMSDataType binaryType;
+    private RDBMSDataType booleanType;
+    private RDBMSDataType doubleType;
+    private RDBMSDataType floatType;
+    private RDBMSDataType integerType;
+    private RDBMSDataType longType;
+    private RDBMSDataType stringType;
+    private RDBMSDataType bigStringType;
 
-    public String getBinaryType() {
+    public RDBMSDataType getBinaryType() {
         return binaryType;
     }
 
-    public void setBinaryType(String binaryType) {
+    public void setBinaryType(RDBMSDataType binaryType) {
         this.binaryType = binaryType;
     }
 
-    public String getBooleanType() {
+    public RDBMSDataType getBooleanType() {
         return booleanType;
     }
 
-    public void setBooleanType(String booleanType) {
+    public void setBooleanType(RDBMSDataType booleanType) {
         this.booleanType = booleanType;
     }
 
-    public String getDoubleType() {
+    public RDBMSDataType getDoubleType() {
         return doubleType;
     }
 
-    public void setDoubleType(String doubleType) {
+    public void setDoubleType(RDBMSDataType doubleType) {
         this.doubleType = doubleType;
     }
 
-    public String getFloatType() {
+    public RDBMSDataType getFloatType() {
         return floatType;
     }
 
-    public void setFloatType(String floatType) {
+    public void setFloatType(RDBMSDataType floatType) {
         this.floatType = floatType;
     }
 
-    public String getIntegerType() {
+    public RDBMSDataType getIntegerType() {
         return integerType;
     }
 
-    public void setIntegerType(String integerType) {
+    public void setIntegerType(RDBMSDataType integerType) {
         this.integerType = integerType;
     }
 
-    public String getLongType() {
+    public RDBMSDataType getLongType() {
         return longType;
     }
 
-    public void setLongType(String longType) {
+    public void setLongType(RDBMSDataType longType) {
         this.longType = longType;
     }
 
-    public String getStringType() {
+    public RDBMSDataType getStringType() {
         return stringType;
     }
 
-    public void setStringType(String stringType) {
+    public void setStringType(RDBMSDataType stringType) {
         this.stringType = stringType;
     }
 
-    public String getBigStringType() {
+    public RDBMSDataType getBigStringType() {
         return bigStringType;
     }
 
-    public void setBigStringType(String bigStringType) {
+    public void setBigStringType(RDBMSDataType bigStringType) {
         this.bigStringType = bigStringType;
     }
 }

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableConstants.java
@@ -131,6 +131,7 @@ public class RDBMSTableConstants {
     public static final String MICROSOFT_SQL_SERVER_NAME = "Microsoft SQL Server";
 
     public static final String USE_COLLATION = "use.collation";
+    public static final String ALLOW_NULL = "allow.null.values";
 
     private RDBMSTableConstants() {
         //preventing initialization

--- a/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableUtils.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/util/RDBMSTableUtils.java
@@ -1,20 +1,20 @@
 /*
-*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing,
-* software distributed under the License is distributed on an
-* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-* KIND, either express or implied.  See the License for the
-* specific language governing permissions and limitations
-* under the License.
-*/
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package io.siddhi.extension.store.rdbms.util;
 
 import com.google.common.collect.Maps;
@@ -25,6 +25,7 @@ import io.siddhi.extension.store.rdbms.RDBMSCompiledCondition;
 import io.siddhi.extension.store.rdbms.RDBMSCompiledSelection;
 import io.siddhi.extension.store.rdbms.config.RDBMSQueryConfiguration;
 import io.siddhi.extension.store.rdbms.config.RDBMSQueryConfigurationEntry;
+import io.siddhi.extension.store.rdbms.config.RDBMSTypeMapping;
 import io.siddhi.extension.store.rdbms.exception.RDBMSTableException;
 import io.siddhi.query.api.annotation.Annotation;
 import io.siddhi.query.api.annotation.Element;
@@ -74,9 +75,9 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableConstants.WHITESPAC
  */
 public class RDBMSTableUtils {
 
-    private static RDBMSConfigurationMapper mapper;
     private static final Log log = LogFactory.getLog(RDBMSTableUtils.class);
     private static final Pattern CONTAINS_CONDITION_REGEX_PATTERN = Pattern.compile(CONTAINS_CONDITION_REGEX);
+    private static RDBMSConfigurationMapper mapper;
 
     private RDBMSTableUtils() {
         //preventing initialization
@@ -166,7 +167,8 @@ public class RDBMSTableUtils {
      *                      (e.g. type mismatches)
      */
     public static int resolveCondition(PreparedStatement stmt, RDBMSCompiledCondition compiledCondition,
-                                        Map<String, Object> conditionParameterMap, int seed) throws SQLException {
+                                       Map<String, Object> conditionParameterMap, int seed,
+                                       RDBMSTypeMapping typeMapping) throws SQLException {
         int maxOrdinal = 0;
         SortedMap<Integer, Object> parameters = compiledCondition.getParameters();
         for (Map.Entry<Integer, Object> entry : parameters.entrySet()) {
@@ -178,11 +180,11 @@ public class RDBMSTableUtils {
             if (parameter instanceof Constant) {
                 Constant constant = (Constant) parameter;
                 populateStatementWithSingleElement(stmt, seed + ordinal, constant.getType(),
-                        constant.getValue());
+                        constant.getValue(), typeMapping);
             } else {
                 Attribute variable = (Attribute) parameter;
                 populateStatementWithSingleElement(stmt, seed + ordinal, variable.getType(),
-                        conditionParameterMap.get(variable.getName()));
+                        conditionParameterMap.get(variable.getName()), typeMapping);
             }
         }
         return maxOrdinal;
@@ -191,38 +193,40 @@ public class RDBMSTableUtils {
     public static void resolveQuery(PreparedStatement stmt, RDBMSCompiledSelection rdbmsCompiledSelection,
                                     RDBMSCompiledCondition rdbmsCompiledCondition,
                                     Map<String, Object> conditionParameterMap, int seed,
-                                    boolean isContainsConditionExist) throws SQLException {
+                                    boolean isContainsConditionExist, RDBMSTypeMapping typeMapping)
+            throws SQLException {
         seed = seed + resolveCondition(stmt, rdbmsCompiledSelection.getCompiledSelectClause(),
-                conditionParameterMap, seed);
+                conditionParameterMap, seed, typeMapping);
 
         if (rdbmsCompiledCondition != null) {
             if (isContainsConditionExist) {
                 seed = seed + resolveConditionForContainsCheck(stmt, rdbmsCompiledCondition, conditionParameterMap,
-                                                                seed);
+                        seed, typeMapping);
             } else {
-                seed = seed + resolveCondition(stmt, rdbmsCompiledCondition, conditionParameterMap, seed);
+                seed = seed + resolveCondition(stmt, rdbmsCompiledCondition, conditionParameterMap, seed, typeMapping);
             }
         }
 
         RDBMSCompiledCondition groupByClause = rdbmsCompiledSelection.getCompiledGroupByClause();
         if (groupByClause != null) {
-            seed = seed + resolveCondition(stmt, groupByClause, conditionParameterMap, seed);
+            seed = seed + resolveCondition(stmt, groupByClause, conditionParameterMap, seed, typeMapping);
         }
 
         RDBMSCompiledCondition havingClause = rdbmsCompiledSelection.getCompiledHavingClause();
         if (havingClause != null) {
-            seed = seed + resolveCondition(stmt, havingClause, conditionParameterMap, seed);
+            seed = seed + resolveCondition(stmt, havingClause, conditionParameterMap, seed, typeMapping);
         }
 
         RDBMSCompiledCondition orderByClause = rdbmsCompiledSelection.getCompiledOrderByClause();
         if (orderByClause != null) {
-            resolveCondition(stmt, orderByClause, conditionParameterMap, seed);
+            resolveCondition(stmt, orderByClause, conditionParameterMap, seed, typeMapping);
         }
     }
 
     public static int resolveConditionForContainsCheck(PreparedStatement stmt,
-                                                        RDBMSCompiledCondition compiledCondition,
-                                                        Map<String, Object> conditionParameterMap, int seed)
+                                                       RDBMSCompiledCondition compiledCondition,
+                                                       Map<String, Object> conditionParameterMap, int seed,
+                                                       RDBMSTypeMapping typeMapping)
             throws SQLException {
         int maxOrdinal = 0;
         SortedMap<Integer, Object> parameters = compiledCondition.getParameters();
@@ -236,19 +240,19 @@ public class RDBMSTableUtils {
                 Constant constant = (Constant) parameter;
                 if (compiledCondition.getOrdinalOfContainPattern().contains(entry.getKey())) {
                     populateStatementWithSingleElement(stmt, seed + entry.getKey(), constant.getType(),
-                            "%" + constant.getValue() + "%");
+                            "%" + constant.getValue() + "%", typeMapping);
                 } else {
                     populateStatementWithSingleElement(stmt, seed + entry.getKey(), constant.getType(),
-                            constant.getValue());
+                            constant.getValue(), typeMapping);
                 }
             } else {
                 Attribute variable = (Attribute) parameter;
                 if (compiledCondition.getOrdinalOfContainPattern().contains(entry.getKey())) {
                     populateStatementWithSingleElement(stmt, seed + entry.getKey(), variable.getType(),
-                            "%" + conditionParameterMap.get(variable.getName()) + "%");
+                            "%" + conditionParameterMap.get(variable.getName()) + "%", typeMapping);
                 } else {
                     populateStatementWithSingleElement(stmt, seed + entry.getKey(), variable.getType(),
-                            conditionParameterMap.get(variable.getName()));
+                            conditionParameterMap.get(variable.getName()), typeMapping);
                 }
 
             }
@@ -257,7 +261,8 @@ public class RDBMSTableUtils {
     }
 
     public static int enumerateUpdateSetEntries(Map<String, CompiledExpression> updateSetExpressions,
-                                                PreparedStatement stmt, Map<String, Object> updateSetMap)
+                                                PreparedStatement stmt, Map<String, Object> updateSetMap,
+                                                RDBMSTypeMapping typeMapping)
             throws SQLException {
         Object parameter;
         int ordinal = 1;
@@ -268,11 +273,11 @@ public class RDBMSTableUtils {
                 if (parameter instanceof Constant) {
                     Constant constant = (Constant) parameter;
                     RDBMSTableUtils.populateStatementWithSingleElement(stmt, ordinal, constant.getType(),
-                            constant.getValue());
+                            constant.getValue(), typeMapping);
                 } else {
                     Attribute variable = (Attribute) parameter;
                     RDBMSTableUtils.populateStatementWithSingleElement(stmt, ordinal, variable.getType(),
-                            updateSetMap.get(variable.getName()));
+                            updateSetMap.get(variable.getName()), typeMapping);
                 }
                 ordinal++;
             }
@@ -291,28 +296,57 @@ public class RDBMSTableUtils {
      * @throws SQLException if there are issues when the element is being set.
      */
     public static void populateStatementWithSingleElement(PreparedStatement stmt, int ordinal, Attribute.Type type,
-                                                          Object value) throws SQLException {
+                                                          Object value, RDBMSTypeMapping typeMapping)
+            throws SQLException {
         switch (type) {
             case BOOL:
-                stmt.setBoolean(ordinal, (Boolean) value);
+                if (value != null) {
+                    stmt.setBoolean(ordinal, (Boolean) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getBooleanType().getTypeValue());
+                }
                 break;
             case DOUBLE:
-                stmt.setDouble(ordinal, (Double) value);
+                if (value != null) {
+                    stmt.setDouble(ordinal, (Double) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getDoubleType().getTypeValue());
+                }
                 break;
             case FLOAT:
-                stmt.setFloat(ordinal, (Float) value);
+                if (value != null) {
+                    stmt.setFloat(ordinal, (Float) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getFloatType().getTypeValue());
+                }
                 break;
             case INT:
-                stmt.setInt(ordinal, (Integer) value);
+                if (value != null) {
+                    stmt.setInt(ordinal, (Integer) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getIntegerType().getTypeValue());
+                }
                 break;
             case LONG:
-                stmt.setLong(ordinal, (Long) value);
+                if (value != null) {
+                    stmt.setLong(ordinal, (Long) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getLongType().getTypeValue());
+                }
                 break;
             case OBJECT:
-                stmt.setObject(ordinal, value);
+                if (value != null) {
+                    stmt.setObject(ordinal, value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getBinaryType().getTypeValue());
+                }
                 break;
             case STRING:
-                stmt.setString(ordinal, (String) value);
+                if (value != null) {
+                    stmt.setString(ordinal, (String) value);
+                } else {
+                    stmt.setNull(ordinal, typeMapping.getStringType().getTypeValue());
+                }
                 break;
         }
     }

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -3,17 +3,20 @@
     <database name="h2">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} LIMIT 1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT TOP 1 1 FROM {{TABLE_NAME}} {{CONDITION}}</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
         <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}}
-            {{CONDITION}}</recordUpdateQuery>
+            {{CONDITION}}
+        </recordUpdateQuery>
         <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
         <recordContainsCondition>{{COLUMNS}} LIKE {{VALUES}}</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -26,19 +29,41 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>TINYINT(1)</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>FLOAT</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>TINYINT(1)</typeName>
+                <typeValue>-6</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>DOUBLE</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>FLOAT</typeName>
+                <typeValue>6</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
     </database>
     <database name="mysql">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} LIMIT 1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -47,7 +72,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -60,20 +86,42 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>TINYINT(1)</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>FLOAT</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>TINYINT(1)</typeName>
+                <typeValue>-6</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>DOUBLE</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>FLOAT</typeName>
+                <typeValue>6</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
         <collation>latin1_bin</collation>
     </database>
-    <database name="oracle" maxVersion = "12.0">
+    <database name="oracle" maxVersion="12.0">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} WHERE rownum=1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}}</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -82,12 +130,15 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
             <orderByClause>ORDER BY {{COLUMNS}}</orderByClause>
-            <queryWrapperClause>SELECT * FROM (SELECT A.*, ROWNUM rn FROM ({{INNER_QUERY}}) A {{LIMIT_WRAPPER}}) {{OFFSET_WRAPPER}}</queryWrapperClause>
+            <queryWrapperClause>SELECT * FROM (SELECT A.*, ROWNUM rn FROM ({{INNER_QUERY}}) A {{LIMIT_WRAPPER}})
+                {{OFFSET_WRAPPER}}
+            </queryWrapperClause>
             <limitWrapperClause>WHERE ROWNUM &lt;= {{Q}}</limitWrapperClause>
             <offsetWrapperClause>WHERE rn &gt; {{Q}}</offsetWrapperClause>
             <limitClause>FETCH NEXT {{Q}} ROWS ONLY</limitClause>
@@ -99,20 +150,45 @@
         <batchEnable>false</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>NUMBER(1)</booleanType>
-            <doubleType>NUMBER(19,4)</doubleType>
-            <floatType>NUMBER(19,4)</floatType>
-            <integerType>NUMBER(10)</integerType>
-            <longType>NUMBER(19)</longType>
-            <stringType>VARCHAR</stringType>
-            <bigStringType>CLOB</bigStringType>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>NUMBER(1)</typeName>
+                <typeValue>2</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>NUMBER(19,4)</typeName>
+                <typeValue>2</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>NUMBER(19,4)</typeName>
+                <typeValue>2</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>NUMBER(10)</typeName>
+                <typeValue>2</typeValue>
+            </integerType>
+            <longType>
+                <typeName>NUMBER(19)</typeName>
+                <typeValue>2</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
+            <bigStringType>
+                <typeName>CLOB</typeName>
+                <typeValue>2005</typeValue>
+            </bigStringType>
         </typeMapping>
     </database>
-    <database name="oracle" minVersion = "12.1">
+    <database name="oracle" minVersion="12.1">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} WHERE rownum=1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}}</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -121,7 +197,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -135,20 +212,45 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>NUMBER(1)</booleanType>
-            <doubleType>NUMBER(19,4)</doubleType>
-            <floatType>NUMBER(19,4)</floatType>
-            <integerType>NUMBER(10)</integerType>
-            <longType>NUMBER(19)</longType>
-            <stringType>VARCHAR</stringType>
-            <bigStringType>CLOB</bigStringType>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>NUMBER(1)</typeName>
+                <typeValue>2</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>NUMBER(19,4)</typeName>
+                <typeValue>2</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>NUMBER(19,4)</typeName>
+                <typeValue>2</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>NUMBER(10)</typeName>
+                <typeValue>2</typeValue>
+            </integerType>
+            <longType>
+                <typeName>NUMBER(19)</typeName>
+                <typeValue>2</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
+            <bigStringType>
+                <typeName>CLOB</typeName>
+                <typeValue>2005</typeValue>
+            </bigStringType>
         </typeMapping>
     </database>
     <database name="Microsoft SQL Server">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT TOP 1 1 from {{TABLE_NAME}}</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT TOP 1 1 FROM {{TABLE_NAME}} {{CONDITION}}</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -157,7 +259,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -170,20 +273,42 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>VARBINARY(max)</binaryType>
-            <booleanType>BIT</booleanType>
-            <doubleType>FLOAT(32)</doubleType>
-            <floatType>REAL</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>VARBINARY(max)
+                <typeName>VARBINARY(max)</typeName>
+                <typeValue>-3</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>BIT</typeName>
+                <typeValue>-7</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>FLOAT(32)</typeName>
+                <typeValue>6</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>REAL</typeName>
+                <typeValue>7</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
         <collation>SQL_Latin1_General_CP1_CS_AS</collation>
     </database>
     <database name="PostgreSQL">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} LIMIT 1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -192,7 +317,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -205,19 +331,41 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BYTEA</binaryType>
-            <booleanType>BOOLEAN</booleanType>
-            <doubleType>DOUBLE PRECISION</doubleType>
-            <floatType>REAL</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>
+                <typeName>BYTEA</typeName>
+                <typeValue>17</typeValue>
+            </binaryType>
+            <booleanType>BOOLEAN
+                <typeName>BOOLEAN</typeName>
+                <typeValue>16</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>DOUBLE</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>REAL</typeName>
+                <typeValue>7</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
     </database>
     <database name="DB2.*">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} FETCH FIRST 1 ROWS ONLY</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} FETCH FIRST 1 ROWS ONLY</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -226,7 +374,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -240,19 +389,41 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB(64000)</binaryType>
-            <booleanType>SMALLINT</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>REAL</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>
+                <typeName>BLOB(64000)</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>SMALLINT</typeName>
+                <typeValue>5</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>DOUBLE</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>REAL</typeName>
+                <typeValue>7</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
     </database>
     <database name="Apache Derby">
         <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
         <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} LIMIT 1</tableCheckQuery>
-        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})</indexCreateQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ON {{TABLE_NAME}} ({{INDEX_COLUMNS}})
+        </indexCreateQuery>
         <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} LIMIT 1</recordExistsQuery>
         <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
         <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
@@ -261,7 +432,8 @@
         <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
         <selectQueryTemplate>
             <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
-            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2 </selectQueryWithSubSelect>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
             <whereClause>WHERE {{CONDITION}}</whereClause>
             <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
             <havingClause>HAVING {{CONDITION}}</havingClause>
@@ -274,13 +446,34 @@
         <batchEnable>true</batchEnable>
         <batchSize>1000</batchSize>
         <typeMapping>
-            <binaryType>BLOB</binaryType>
-            <booleanType>TINYINT(1)</booleanType>
-            <doubleType>DOUBLE</doubleType>
-            <floatType>FLOAT</floatType>
-            <integerType>INTEGER</integerType>
-            <longType>BIGINT</longType>
-            <stringType>VARCHAR</stringType>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>TINYINT(1)</typeName>
+                <typeValue>-6</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>DOUBLE</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>FLOAT</typeName>
+                <typeValue>6</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
         </typeMapping>
     </database>
 </rdbms-table-configuration>

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
@@ -23,7 +23,6 @@ import io.siddhi.core.event.Event;
 import io.siddhi.core.query.output.callback.QueryCallback;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
-import io.siddhi.extension.store.rdbms.exception.RDBMSTableException;
 import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
 import org.apache.log4j.Logger;
 import org.awaitility.Awaitility;

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/InsertIntoRDBMSTableTestCaseIT.java
@@ -23,6 +23,7 @@ import io.siddhi.core.event.Event;
 import io.siddhi.core.query.output.callback.QueryCallback;
 import io.siddhi.core.stream.input.InputHandler;
 import io.siddhi.core.util.EventPrinter;
+import io.siddhi.extension.store.rdbms.exception.RDBMSTableException;
 import io.siddhi.extension.store.rdbms.util.RDBMSTableTestUtils;
 import org.apache.log4j.Logger;
 import org.awaitility.Awaitility;
@@ -232,6 +233,80 @@ public class InsertIntoRDBMSTableTestCaseIT {
         joinStream.send(new Object[]{"wso2"});
         waitTillVariableCountMatches(1, Duration.ONE_MINUTE);
         Assert.assertEquals(actualEventCount.get(), 1, "Number of success events");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void insertIntoRDBMSTableTest5() throws InterruptedException, SQLException {
+        //Testing data insertion with null values to numeric columns
+        log.info("insertIntoRDBMSTableTest5");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long);\n";
+
+        String table = "" +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", table.name=\"StockTable\"," +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\")\n" +
+                "@PrimaryKey(\"symbol\")" +
+                "define table MyTable (symbol string, price float, volume long);\n";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream   " +
+                "select symbol, price, volume " +
+                "insert into MyTable ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + table + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6F, null});
+        stockStream.send(new Object[]{"WSO2", 55.6F, 100L});
+        stockStream.send(new Object[]{"IBM", null, 80L});
+        stockStream.send(new Object[]{"MSFT", 57.6F, 50L});
+        stockStream.send(new Object[]{"BMS", 58.6F, 60L});
+        Thread.sleep(1000);
+
+        long totalRowsInTable = RDBMSTableTestUtils.getRowsInTable(TABLE_NAME);
+        Assert.assertEquals(totalRowsInTable, 3, "Definition/Insertion failed");
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void insertIntoRDBMSTableTest6() throws InterruptedException, SQLException {
+        //Testing data insertion with null values to numeric columns with allow.null.values = true
+        log.info("insertIntoRDBMSTableTest6");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        String streams = "" +
+                "define stream StockStream (symbol string, price float, volume long);\n";
+
+        String table = "" +
+                "@Store(type=\"rdbms\", jdbc.url=\"" + url + "\", table.name=\"StockTable\"," +
+                "username=\"" + user + "\", password=\"" + password + "\", jdbc.driver.name=\"" + driverClassName +
+                "\", field.length=\"symbol:100\", allow.null.values =\"true\")\n" +
+                "@PrimaryKey(\"symbol\")" +
+                "define table MyTable (symbol string, price float, volume long);\n";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream   " +
+                "select symbol, price, volume " +
+                "insert into MyTable ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + table + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        stockStream.send(new Object[]{"WSO2", 55.6F, null});
+        stockStream.send(new Object[]{"BMS", 56.6F, 100L});
+        stockStream.send(new Object[]{"IBM", null, 80L});
+        stockStream.send(new Object[]{"MSFT", 57.6F, 50L});
+        stockStream.send(new Object[]{"LSF", 58.6F, 60L});
+        Thread.sleep(1000);
+
+        long totalRowsInTable = RDBMSTableTestUtils.getRowsInTable(TABLE_NAME);
+        Assert.assertEquals(totalRowsInTable, 5, "Definition/Insertion failed");
         siddhiAppRuntime.shutdown();
     }
 

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/aggregation/SelectOptimisationAggregationTestCaseIT.java
@@ -81,7 +81,7 @@ public class SelectOptimisationAggregationTestCaseIT {
                 "define aggregation stockAggregation " +
                 "from stockStream " +
                 "select count() as count " +
-                "aggregate every sec, min ;" +
+                "aggregate by timestamp every sec, min ;" +
 
                 "define stream inputStream (symbol string, value int, startTime string, " +
                 "endTime string, perValue string); " +


### PR DESCRIPTION
## Purpose
This PR will provide the capability to insert or update a table row with null values for numeric columns.

In order to allow null insertions, please use the ```allow.null.values ="true"``` when defining the table 

fix the issue reported in https://github.com/siddhi-io/siddhi-store-rdbms/issues/144

## Automation tests
 - Unit tests 
  insertIntoRDBMSTableTest6
 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
