### PR TITLE
Add support to read null values as it is

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -692,7 +692,7 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             }
             rs = stmt.executeQuery();
             //Passing all java.sql artifacts to the iterator to ensure everything gets cleaned up at once.
-            return new RDBMSIterator(conn, stmt, rs, this.attributes, this.tableName);
+            return new RDBMSIterator(conn, stmt, rs, this.attributes, this.tableName, allowNullValues);
         } catch (SQLException e) {
             try {
                 boolean isConnValid = conn.isValid(0);
@@ -1905,9 +1905,9 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             // If the outputAttributes are null, it is assumed that all the attributes from the table definition
             // are being selected in the query.
             if (outputAttributes == null) {
-                return new RDBMSIterator(conn, stmt, rs, this.attributes, this.tableName);
+                return new RDBMSIterator(conn, stmt, rs, this.attributes, this.tableName, allowNullValues);
             }
-            return new RDBMSIterator(conn, stmt, rs, Arrays.asList(outputAttributes), this.tableName);
+            return new RDBMSIterator(conn, stmt, rs, Arrays.asList(outputAttributes), this.tableName, allowNullValues);
         } catch (SQLException e) {
             try {
                 boolean isConnValid = conn.isValid(0);


### PR DESCRIPTION
## Purpose
By default, when reading the null value from the database it gets replaced by 0. This is due to the implementation of ResultSet.get() implementation. If the  `allow.null.values ="true"` provided in @store annotation, this will override and returns null values as it is.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes