### PR TITLE
Add improvement to acknowledge when query doesnt return data

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
@@ -169,6 +169,16 @@ import javax.sql.DataSource;
                                 "`attribute.definition.list`(creditcardno, country, transaction, amount). " +
                                 "countrySearchWord value from the event will be set in the query when querying the " +
                                 "datasource."
+                ),
+                @Example(
+                        syntax = "from TriggerStream#rdbms:query('SAMPLE_DB', 'creditcardno string, country string," +
+                                "transaction string, amount int', 'select * from where country=?', " +
+                                "countrySearchWord, true) " +
+                                "select creditcardno, country, transaction, amount \n" +
+                                "insert into recordStream;",
+                        description = "If there are no events in the table which satisfies the given query with " +
+                                "`creditcardno` parameter, the event which gets selected by creditcardno, country, " +
+                                "transaction and amount will contain NULL values."
                 )
         }
 )

--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/util/RDBMSStreamProcessorUtil.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/util/RDBMSStreamProcessorUtil.java
@@ -133,6 +133,14 @@ public class RDBMSStreamProcessorUtil {
         return result.toArray();
     }
 
+    public static Object[] processNullRecord(List<Attribute> attributeList) {
+        List<Object> result = new ArrayList<>();
+        for (int i = 0; i < attributeList.size(); i++) {
+            result.add(null);
+        }
+        return result.toArray();
+    }
+
     /**
      * Utility function for validating the query.
      *

--- a/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
+++ b/component/src/test/java/io/siddhi/extension/execution/rdbms/RDBMSQueryTestCase.java
@@ -280,4 +280,172 @@ public class RDBMSQueryTestCase {
         Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
     }
 
+    @Test(dependsOnMethods = "rdbmsQuery4")
+    public void rdbmsQuery5() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select parameterised query with ack.empty.result.set=true without a match");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=?\", checkSymbol, true) " +
+                "select symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO22"});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = new ArrayList<>();
+        expected.add(new Object[]{null});
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
+    }
+
+    @Test(dependsOnMethods = "rdbmsQuery5")
+    public void rdbmsQuery6() throws InterruptedException {
+        //Testing table query
+        log.info(
+                "rdbmsQuery1 - Test Select parameterised query with ack.empty.result.set set to false without a match");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=?\", checkSymbol, false) " +
+                "select symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                isEventArrived = true;
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO22"});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 5000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        Assert.assertFalse(isEventArrived, "Event Not Arrived");
+    }
+
+    @Test(dependsOnMethods = "rdbmsQuery6")
+    public void rdbmsQuery7() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select multi parameterised query with ack.empty.result.set=true without a match");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string, checkVolume long); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=? and volume=?\", checkSymbol, checkVolume, true) " +
+                "select symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    actualData.add(event.getData());
+                    isEventArrived = true;
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO22", 200L});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        List<Object[]> expected = new ArrayList<>();
+        expected.add(new Object[]{null});
+
+        Assert.assertTrue(isEventArrived, "Event Not Arrived");
+        Assert.assertTrue(SiddhiTestHelper.isEventsMatch(actualData, expected), "Event output does not match.");
+    }
+
+    @Test(dependsOnMethods = "rdbmsQuery7")
+    public void rdbmsQuery8() throws InterruptedException {
+        //Testing table query
+        log.info("rdbmsQuery1 - Test Select multi parameterised query with ack.empty.result.set=false without a match");
+        SiddhiManager siddhiManager = new SiddhiManager();
+        DataSource dataSource = RDBMSTableTestUtils.initDataSource();
+        siddhiManager.setDataSource("TEST_DATASOURCE", dataSource);
+
+        String streams = "" +
+                "define stream StockStream (checkSymbol string, checkVolume long); ";
+
+        String query = "" +
+                "@info(name = 'query1') " +
+                "from StockStream#rdbms:query(\"TEST_DATASOURCE\", \"symbol string, price float, volume long\", " +
+                "\"select * from " + TABLE_NAME + " where symbol=? and volume=?\", checkSymbol, checkVolume, false) " +
+                "select symbol " +
+                "insert into OutputStream ;";
+
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        InputHandler stockStream = siddhiAppRuntime.getInputHandler("StockStream");
+        siddhiAppRuntime.start();
+
+        siddhiAppRuntime.addCallback("OutputStream", new StreamCallback() {
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                isEventArrived = true;
+            }
+        });
+
+        stockStream.send(new Object[]{"WSO22", 123L});
+        SiddhiTestHelper.waitForEvents(2000, 1, eventCount, 60000);
+        siddhiAppRuntime.shutdown();
+        ((HikariDataSource) dataSource).close();
+
+        Assert.assertFalse(isEventArrived, "Event Not Arrived");
+    }
 }


### PR DESCRIPTION
## Purpose
> $subject

## Goals
> Currently the event stream gets dropped at rdbms:query() when the query doesn't return any data. Need to write few siddhi queries to handle if we need to check whether it has dropped.
> With this parameter enabled, with a simple null check on the return attributes the solution can be written.

## Approach
> Generate an event with null values when ResultSet doesnt contain records.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes