### PR TITLE
Add support to read rdbms config file externally

### DIFF
--- a/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
+++ b/component/src/main/java/io/siddhi/extension/store/rdbms/RDBMSEventTable.java
@@ -295,6 +295,8 @@ import static io.siddhi.extension.store.rdbms.util.RDBMSTableUtils.processFindCo
                                 "NOT, str:contains(Table<Column>, Stream<Attribute> or Search.String)]"
                 )
         },
+        //system parameter is used to override any existing default values(eg:- tableCheckQuery , tableCreateQuery etc)
+        // of a particular RDBMS type
         systemParameter = {
                 @SystemParameter(
                         name = "{{RDBMS-Name}}.maxVersion",
@@ -1598,6 +1600,13 @@ public class RDBMSEventTable extends AbstractQueryableRecordTable {
             }
             if (this.queryConfigurationEntry.isKeyExplicitNotNull()) {
                 builder.append(WHITESPACE).append(SQL_NOT_NULL);
+            } else {
+                for (Element key : primaryKeyList) {
+                    if (attribute.getName().equals(key.getValue())) {
+                        builder.append(WHITESPACE).append(SQL_NOT_NULL);
+                        break;
+                    }
+                }
             }
             if (this.attributes.indexOf(attribute) != this.attributes.size() - 1 || !primaryKeyList.isEmpty()) {
                 builder.append(SEPARATOR);

--- a/component/src/main/resources/rdbms-table-config.xml
+++ b/component/src/main/resources/rdbms-table-config.xml
@@ -476,4 +476,59 @@
             </stringType>
         </typeMapping>
     </database>
+    <database name="Teradata">
+        <tableCreateQuery>CREATE TABLE {{TABLE_NAME}} ({{COLUMNS, PRIMARY_KEYS}})</tableCreateQuery>
+        <tableCheckQuery>SELECT 1 FROM {{TABLE_NAME}} SAMPLE 1</tableCheckQuery>
+        <indexCreateQuery>CREATE INDEX {{TABLE_NAME}}_INDEX_{{INDEX_NUM}} ({{INDEX_COLUMNS}}) ON {{TABLE_NAME}}
+        </indexCreateQuery>
+        <recordExistsQuery>SELECT 1 FROM {{TABLE_NAME}} {{CONDITION}} SAMPLE 1</recordExistsQuery>
+        <recordSelectQuery>SELECT * FROM {{TABLE_NAME}} {{CONDITION}}</recordSelectQuery>
+        <recordInsertQuery>INSERT INTO {{TABLE_NAME}} ({{COLUMNS}}) VALUES ({{Q}})</recordInsertQuery>
+        <recordUpdateQuery>UPDATE {{TABLE_NAME}} SET {{COLUMNS_AND_VALUES}} {{CONDITION}}</recordUpdateQuery>
+        <recordDeleteQuery>DELETE FROM {{TABLE_NAME}} {{CONDITION}}</recordDeleteQuery>
+        <recordContainsCondition>({{COLUMNS}} LIKE {{VALUES}})</recordContainsCondition>
+        <selectQueryTemplate>
+            <selectClause>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}</selectClause>
+            <selectQueryWithSubSelect>SELECT {{SELECTORS}} FROM {{TABLE_NAME}}, ( {{INNER_QUERY}} ) AS t2
+            </selectQueryWithSubSelect>
+            <whereClause>WHERE {{CONDITION}}</whereClause>
+            <groupByClause>GROUP BY {{COLUMNS}}</groupByClause>
+            <havingClause>HAVING {{CONDITION}}</havingClause>
+            <orderByClause>ORDER BY {{COLUMNS}}</orderByClause>
+            <limitClause>SAMPLE {{Q}}</limitClause>
+        </selectQueryTemplate>
+        <stringSize>254</stringSize>
+        <batchEnable>true</batchEnable>
+        <batchSize>1000</batchSize>
+        <typeMapping>
+            <binaryType>
+                <typeName>BLOB</typeName>
+                <typeValue>2004</typeValue>
+            </binaryType>
+            <booleanType>
+                <typeName>SMALLINT</typeName>
+                <typeValue>5</typeValue>
+            </booleanType>
+            <doubleType>
+                <typeName>FLOAT</typeName>
+                <typeValue>8</typeValue>
+            </doubleType>
+            <floatType>
+                <typeName>FLOAT</typeName>
+                <typeValue>6</typeValue>
+            </floatType>
+            <integerType>
+                <typeName>INTEGER</typeName>
+                <typeValue>4</typeValue>
+            </integerType>
+            <longType>
+                <typeName>BIGINT</typeName>
+                <typeValue>-5</typeValue>
+            </longType>
+            <stringType>
+                <typeName>VARCHAR</typeName>
+                <typeValue>12</typeValue>
+            </stringType>
+        </typeMapping>
+    </database>
 </rdbms-table-configuration>


### PR DESCRIPTION
## Purpose
Allow external file located at [Product_home]/conf/siddhi/rdbms/rdbms-table-config.xml to be read if exist Fixes https://github.com/wso2/streaming-integrator/issues/241

## Goals
Externalize the rdbms config so that new rdbms type can be provided

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
