### PR TITLE
Fix Hikari pool connection leakage from QueryStreamProcessor

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/ProcedureStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/ProcedureStreamProcessor.java
@@ -329,6 +329,7 @@ public class ProcedureStreamProcessor extends StreamProcessor<State> {
                         streamEventCloner, this.attributeList, event, complexEventPopulater, streamEventChunk);
                 streamEventChunk.remove();
             }
+            RDBMSStreamProcessorUtil.cleanupConnection(null, stmt, conn);
             nextProcessor.process(streamEventChunk);
         } catch (SQLException e) {
             throw new SiddhiAppRuntimeException("Error in retrieving records from  datasource '"

--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/QueryStreamProcessor.java
@@ -324,6 +324,7 @@ public class QueryStreamProcessor extends StreamProcessor<State> {
                 streamEventChunk.remove();
                 RDBMSStreamProcessorUtil.cleanupConnection(resultSet, stmt, null);
             }
+            RDBMSStreamProcessorUtil.cleanupConnection(resultSet, stmt, conn);
             nextProcessor.process(streamEventChunk);
         } catch (SQLException e) {
             throw new SiddhiAppRuntimeException("Error in retrieving records from  datasource '"


### PR DESCRIPTION
## Purpose

- Resolves https://github.com/siddhi-io/siddhi-store-rdbms/issues/246

In QueryStreamProcessor, the database connections are not closed until a processed event is passed to the next event processor. Due to this, the created connections are kept active until the entire flow is completed. Hence, when there are processes that take considerably large time, they will not close the connections and the pool threads are held active, which causes connection leakage and pool thread exhaustion. This is fixed by closing the connection.

