### PR TITLE
Fix ArrayIndexOutOfBoundsException in CUD operation

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/CUDStreamProcessor.java
@@ -314,14 +314,11 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
             if (streamEventChunk.hasNext()) {
                 StreamEvent event = streamEventChunk.next();
                 String query = ((String) queryExpressionExecutor.execute(event));
-                stmt = conn.prepareStatement(query);
-                if (!streamEventChunk.hasNext() && !isQueryParameterised) {
-                    stmt.addBatch();
-                }
                 if (RDBMSStreamProcessorUtil.queryContainsCheck(query)) {
                     throw new SiddhiAppRuntimeException("Dropping event since the query has " +
                             "unauthorised operations, '" + query + "'. Event: '" + event + "'.");
                 }
+                stmt = conn.prepareStatement(query);
             }
             streamEventChunk.reset();
             while (streamEventChunk.hasNext()) {
@@ -337,8 +334,8 @@ public class CUDStreamProcessor extends StreamProcessor<State> {
                                 attributeExpressionExecutor.getReturnType(),
                                 attributeExpressionExecutor.execute(event));
                     }
-                    stmt.addBatch();
                 }
+                stmt.addBatch();
             }
             int counter = 0;
             if (stmt != null) {

--- a/component/src/test/java/io/siddhi/extension/store/rdbms/util/RDBMSTableTestUtils.java
+++ b/component/src/test/java/io/siddhi/extension/store/rdbms/util/RDBMSTableTestUtils.java
@@ -89,6 +89,10 @@ public class RDBMSTableTestUtils {
     }
 
     public static DataSource initDataSource() {
+        return initDataSource(true);
+    }
+
+    public static DataSource initDataSource(boolean isAutoCommit) {
         String databaseType = System.getenv("DATABASE_TYPE");
         if (databaseType == null) {
             databaseType = TestType.H2.toString();
@@ -151,6 +155,7 @@ public class RDBMSTableTestUtils {
         connectionProperties.setProperty("poolName", "Test_Pool");
         connectionProperties.setProperty("maximumPoolSize", "4");
         HikariConfig config = new HikariConfig(connectionProperties);
+        config.setAutoCommit(isAutoCommit);
         return new HikariDataSource(config);
     }
 


### PR DESCRIPTION
## Purpose
This PR fixes an `ArrayIndexOutOfBoundsException` while trying to commit a transaction via `rdbms:cud` operation.

Resolves https://github.com/wso2/api-manager/issues/2021

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes