### PR TITLE
Add System Property to Allow Null Parameters with CUD Functions

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/rdbms/util/RDBMSStreamProcessorUtil.java
+++ b/component/src/main/java/io/siddhi/extension/execution/rdbms/util/RDBMSStreamProcessorUtil.java
@@ -217,6 +217,11 @@ public class RDBMSStreamProcessorUtil {
      */
     public static void populateStatementWithSingleElement(PreparedStatement stmt, int ordinal, Attribute.Type type,
                                                           Object value) throws SQLException {
+        // Handle 'null' valued params separately
+        if (value == null) {
+            stmt.setObject(ordinal, null);
+            return;
+        }
         switch (type) {
             case BOOL:
                 stmt.setBoolean(ordinal, (Boolean) value);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/2680

## Approach
Introduced a new `allow.null.params.with.CUD` system property to allow null valued parameters to be passed to CUD functions. By default this is set to `false`.

```
    siddhi:
      extensions:
        - extension:
            name: cud
            namespace: rdbms
            properties:
              perform.CUD.operations: true
              allow.null.params.with.CUD: true
```
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
